### PR TITLE
feat: belongsTo

### DIFF
--- a/code_stubs/BelongsTo.stub
+++ b/code_stubs/BelongsTo.stub
@@ -1,0 +1,4 @@
+    public function {relation}(): BelongsTo
+    {
+        return $this->belongsTo({relation_model}::class, '{relation_column}'{relation_id});
+    }

--- a/code_stubs/Model.stub
+++ b/code_stubs/Model.stub
@@ -6,6 +6,7 @@ namespace {namespace};
 
 {use_soft_deletes}
 use Illuminate\Database\Eloquent\Model;
+{use_belongs_to}
 
 class {class} extends Model
 {
@@ -13,5 +14,5 @@ class {class} extends Model
 {timestamps}
 {table}
     protected $fillable = [{fillable}
-    ];
+    ];{belongs_to}
 }

--- a/code_stubs/Select.stub
+++ b/code_stubs/Select.stub
@@ -1,0 +1,6 @@
+	<div>
+		<label for="{column}">{label}</label>
+		<select id="{column}" name="{column}">
+		    <option value="">Not selected</option>
+		</select>
+	</div>

--- a/config/code_builder.php
+++ b/config/code_builder.php
@@ -18,4 +18,6 @@ return [
 //    'generation_path' => 'Generation',
 
 //    'stub_dir' => base_path('code_stubs'),
+
+//    'belongs_to' => true,
 ];

--- a/src/Commands/LaravelCodeBuildCommand.php
+++ b/src/Commands/LaravelCodeBuildCommand.php
@@ -65,7 +65,16 @@ class LaravelCodeBuildCommand extends Command
             throw new Exception('entity must be a string');
         }
 
-        $this->codeStructure = CodeStructureFactory::makeFromTable((string) $table, (string) $entity);
+        $confirmBelongsTo = config('code_builder.belongs_to');
+        if(is_null($confirmBelongsTo)) {
+            $confirmBelongsTo = confirm("Generate BelongsTo relations from foreign keys?");
+        }
+
+        $this->codeStructure = CodeStructureFactory::makeFromTable(
+            (string) $table,
+            (string) $entity,
+            $confirmBelongsTo
+        );
 
         $this->codeStructure->setStubDir($stubDir);
 

--- a/src/Enums/SqlTypeMap.php
+++ b/src/Enums/SqlTypeMap.php
@@ -111,7 +111,8 @@ enum SqlTypeMap: string
             self::UNSIGNED_TINY_INTEGER,
             self::DECIMAL,
             self::DOUBLE,
-            self::FLOAT
+            self::FLOAT,
+            self::BELONGS_TO
             => 'number',
 
             /*Switcher*/
@@ -144,7 +145,6 @@ enum SqlTypeMap: string
             /*Relations*/
             self::HAS_ONE => 'HasOne',
             self::HAS_MANY => 'HasMany',
-            self::BELONGS_TO => 'BelongsTo',
         };
     }
 

--- a/src/Enums/StubValue.php
+++ b/src/Enums/StubValue.php
@@ -14,6 +14,10 @@ enum StubValue
 
     case TABLE;
 
+    case USE_BELONGS_TO;
+
+    case BELONGS_TO;
+
     function key(): string
     {
         return match ($this) {
@@ -21,6 +25,8 @@ enum StubValue
             self::SOFT_DELETES => '{soft_deletes}',
             self::TIMESTAMPS => '{timestamps}',
             self::TABLE => '{table}',
+            self::USE_BELONGS_TO => '{use_belongs_to}',
+            self::BELONGS_TO => '{belongs_to}',
         };
     }
 
@@ -31,6 +37,8 @@ enum StubValue
             self::SOFT_DELETES => "\tuse SoftDeletes;",
             self::TIMESTAMPS => "\tpublic \$timestamps = false;",
             self::TABLE => "\tprotected \$table = ",
+            self::USE_BELONGS_TO => "use Illuminate\Database\Eloquent\Relations\BelongsTo;",
+            default => '',
         };
     }
 }

--- a/src/Services/Builders/ModelBuilder.php
+++ b/src/Services/Builders/ModelBuilder.php
@@ -20,6 +20,10 @@ class ModelBuilder extends AbstractBuilder
     {
         $modelPath = $this->codePath->path(BuildType::MODEL->value);
 
+
+        $belongsToStr = $this->codeStructure->hasBelongsTo()
+            ? $this->codeStructure->belongsToInModel() : '';
+
         StubBuilder::make($this->stubFile)
             ->setKey(
                 StubValue::USE_SOFT_DELETES->key(),
@@ -30,15 +34,28 @@ class ModelBuilder extends AbstractBuilder
                 StubValue::SOFT_DELETES->key(),
                 StubValue::SOFT_DELETES->value().PHP_EOL,
                 $this->codeStructure->isSoftDeletes()
-            )->setKey(
+            )
+            ->setKey(
+                StubValue::USE_BELONGS_TO->key(),
+                StubValue::USE_BELONGS_TO->value(),
+                $this->codeStructure->hasBelongsTo()
+            )
+            ->setKey(
+                StubValue::BELONGS_TO->key(),
+                $belongsToStr,
+                ! empty($belongsToStr)
+            )
+            ->setKey(
                 StubValue::TIMESTAMPS->key(),
                 StubValue::TIMESTAMPS->value().PHP_EOL,
                 ! $this->codeStructure->isTimestamps()
-            )->setKey(
+            )
+            ->setKey(
                 StubValue::TABLE->key(),
                 StubValue::TABLE->value() . " '{$this->codeStructure->table()}';\n",
                 $this->codeStructure->table() !== $this->codeStructure->entity()->str()->plural()->snake()->value()
-            )->makeFromStub($modelPath->file(), [
+            )
+            ->makeFromStub($modelPath->file(), [
                 '{namespace}' => $modelPath->namespace(),
                 '{class}' => $this->codeStructure->entity()->ucFirstSingular(),
                 '{fillable}' => $this->codeStructure->columnsToModel(),

--- a/src/Services/CodeStructure/ColumnStructure.php
+++ b/src/Services/CodeStructure/ColumnStructure.php
@@ -12,6 +12,8 @@ final class ColumnStructure
 
     private ?string $inputType = null;
 
+    private ?RelationStructure $relation = null;
+
     public function __construct(
         private readonly string $column,
         private string $name = ''
@@ -36,11 +38,21 @@ final class ColumnStructure
         return $this->name;
     }
 
+    public function relation(): ?RelationStructure
+    {
+        return $this->relation;
+    }
+
     public function setType(string $type): void
     {
         $this->type = $type;
 
         $this->setInputType();
+    }
+
+    public function setRelation(string $foreignColumn, string $table): void
+    {
+        $this->relation = new RelationStructure($foreignColumn, $table);
     }
 
     public function inputType(): ?string
@@ -75,6 +87,10 @@ final class ColumnStructure
 
     public function rulesType(): ?string
     {
+        if($this->inputType === 'number') {
+            return 'int';
+        }
+
         if($this->inputType === 'number') {
             return 'int';
         }

--- a/src/Services/CodeStructure/RelationStructure.php
+++ b/src/Services/CodeStructure/RelationStructure.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DevLnk\LaravelCodeBuilder\Services\CodeStructure;
+
+use DevLnk\LaravelCodeBuilder\Support\NameStr;
+
+final class RelationStructure
+{
+    private NameStr $table;
+
+    public function __construct(
+        private readonly string $foreignColumn,
+        string $table
+    ) {
+        $this->table = new NameStr($table);
+    }
+
+    public function foreignColumn(): string
+    {
+        return $this->foreignColumn;
+    }
+
+    public function table(): NameStr
+    {
+        return $this->table;
+    }
+}

--- a/src/Services/StubBuilder.php
+++ b/src/Services/StubBuilder.php
@@ -90,6 +90,7 @@ final class StubBuilder
             ->replace("\r", "")
             ->replace(array_map(fn($item) => "\n\n$item", $this->removers), "")
             ->replace(array_map(fn($item) => "\n$item", $this->removers), "")
+            ->replace(array_map(fn($item) => "$item", $this->removers), "")
             ->value();
 
         return $this;

--- a/tests/Feature/CommandFormTest.php
+++ b/tests/Feature/CommandFormTest.php
@@ -36,6 +36,8 @@ final class CommandFormTest extends TestCase
         $this->assertStringContainsString("<form action=\"{{ route('product.store') }}\" method=\"POST\">", $file);
         $this->assertStringContainsString('<input id="content" name="content" value="{{ old(\'content\') }}"/>', $file);
         $this->assertStringContainsString('<input id="sort_number" name="sort_number" value="{{ old(\'sort_number\') }}" type="number"/>', $file);
+        $this->assertStringContainsString('<select id="user_id" name="user_id">', $file);
+        $this->assertStringContainsString('<select id="category_id" name="category_id">', $file);
     }
 
     #[Test]

--- a/tests/Feature/CommandModelTest.php
+++ b/tests/Feature/CommandModelTest.php
@@ -38,6 +38,9 @@ class CommandModelTest extends TestCase
         $this->assertStringContainsString('protected $fillable = [', $file);
         $this->assertStringContainsString('class Product extends Model', $file);
         $this->assertStringContainsString('use SoftDeletes;', $file);
+        $this->assertStringContainsString('use Illuminate\Database\Eloquent\Relations\BelongsTo;', $file);
+        $this->assertStringContainsString("return \$this->belongsTo(User::class, 'user_id');", $file);
+        $this->assertStringContainsString("return \$this->belongsTo(Category::class, 'category_id');", $file);
         $this->assertStringNotContainsString('public $timestamps = false;', $file);
 
         $this->assertStringContainsString('title', $file);

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -7,6 +7,7 @@ namespace DevLnk\LaravelCodeBuilder\Tests;
 use DevLnk\LaravelCodeBuilder\Providers\LaravelCodeBuilderProvider;
 use DevLnk\LaravelCodeBuilder\Tests\Fixtures\TestServiceProvider;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Config;
 use Orchestra\Testbench\TestCase as Orchestra;
 
 class TestCase extends Orchestra
@@ -23,6 +24,8 @@ class TestCase extends Orchestra
     protected function performApplication(): void
     {
         $this->artisan('vendor:publish --tag=laravel-code-builder');
+
+        Config::set('code_builder.belongs_to', true);
     }
 
     protected function getPackageProviders($app): array


### PR DESCRIPTION
Added support for belongsTo relationships. If a field has a foreign key in the table, then the field will be considered BelongsTo. 
```php
public function user(): BelongsTo
{
    return $this->belongsTo(User::class, 'user_id', 'id');
}

public function category(): BelongsTo
{
    return $this->belongsTo(Category::class, 'category_id', 'id');
}
```
BelongsTo fields in the form will form select input. 

New option in the configuration file `belongs_to`. If false, then BelongsTo fields will not be searched. If not set, a confirmation dialog will be shown when generating the code.

**Carefully!** If the relationship model is not in the current namespace, you need to import.