### PR TITLE
HasOne, HasMany types

### DIFF
--- a/code_stubs/HasMany.stub
+++ b/code_stubs/HasMany.stub
@@ -1,0 +1,4 @@
+    public function {relation}(): HasMany
+    {
+        return $this->hasMany({relation_model}::class, '{relation_column}');
+    }

--- a/code_stubs/HasOne.stub
+++ b/code_stubs/HasOne.stub
@@ -1,0 +1,4 @@
+    public function {relation}(): HasOne
+    {
+        return $this->hasOne({relation_model}::class, '{relation_column}');
+    }

--- a/code_stubs/Model.stub
+++ b/code_stubs/Model.stub
@@ -7,6 +7,8 @@ namespace {namespace};
 {use_soft_deletes}
 use Illuminate\Database\Eloquent\Model;
 {use_belongs_to}
+{use_has_many}
+{use_has_one}
 
 class {class} extends Model
 {
@@ -14,5 +16,5 @@ class {class} extends Model
 {timestamps}
 {table}
     protected $fillable = [{fillable}
-    ];{belongs_to}
+    ];{relations}
 }

--- a/src/Commands/LaravelCodeBuildCommand.php
+++ b/src/Commands/LaravelCodeBuildCommand.php
@@ -20,7 +20,7 @@ use function Laravel\Prompts\select;
 
 class LaravelCodeBuildCommand extends Command
 {
-    protected $signature = 'code:build {entity} {table?} {--only=}';
+    protected $signature = 'code:build {entity} {table?} {--only=} {--has-many=*} {--has-one=*}';
 
     private CodePath $codePath;
 
@@ -70,10 +70,22 @@ class LaravelCodeBuildCommand extends Command
             $confirmBelongsTo = confirm("Generate BelongsTo relations from foreign keys?");
         }
 
+        $hasMany = $this->option('has-many');
+        if(! is_array($hasMany)) {
+            throw new Exception('has-many flag must be an array');
+        }
+
+        $hasOne = $this->option('has-one');
+        if(! is_array($hasOne)) {
+            throw new Exception('has-one flag must be an array');
+        }
+
         $this->codeStructure = CodeStructureFactory::makeFromTable(
             (string) $table,
             (string) $entity,
-            $confirmBelongsTo
+            $confirmBelongsTo,
+            $hasMany,
+            $hasOne
         );
 
         $this->codeStructure->setStubDir($stubDir);

--- a/src/Enums/StubValue.php
+++ b/src/Enums/StubValue.php
@@ -16,17 +16,23 @@ enum StubValue
 
     case USE_BELONGS_TO;
 
-    case BELONGS_TO;
+    case USE_HAS_MANY;
+
+    case USE_HAS_ONE;
+
+    case RELATIONS;
 
     function key(): string
     {
         return match ($this) {
             self::USE_SOFT_DELETES => '{use_soft_deletes}',
+            self::USE_BELONGS_TO => '{use_belongs_to}',
+            self::USE_HAS_MANY => '{use_has_many}',
+            self::USE_HAS_ONE => '{use_has_one}',
             self::SOFT_DELETES => '{soft_deletes}',
             self::TIMESTAMPS => '{timestamps}',
             self::TABLE => '{table}',
-            self::USE_BELONGS_TO => '{use_belongs_to}',
-            self::BELONGS_TO => '{belongs_to}',
+            self::RELATIONS => '{relations}',
         };
     }
 
@@ -38,6 +44,8 @@ enum StubValue
             self::TIMESTAMPS => "\tpublic \$timestamps = false;",
             self::TABLE => "\tprotected \$table = ",
             self::USE_BELONGS_TO => "use Illuminate\Database\Eloquent\Relations\BelongsTo;",
+            self::USE_HAS_MANY => "use Illuminate\Database\Eloquent\Relations\HasMany;",
+            self::USE_HAS_ONE => "use Illuminate\Database\Eloquent\Relations\HasOne;",
             default => '',
         };
     }

--- a/src/Services/Builders/ModelBuilder.php
+++ b/src/Services/Builders/ModelBuilder.php
@@ -21,8 +21,8 @@ class ModelBuilder extends AbstractBuilder
         $modelPath = $this->codePath->path(BuildType::MODEL->value);
 
 
-        $belongsToStr = $this->codeStructure->hasBelongsTo()
-            ? $this->codeStructure->belongsToInModel() : '';
+        $relations = $this->codeStructure->hasBelongsTo()
+            ? $this->codeStructure->relationsToModel() : '';
 
         StubBuilder::make($this->stubFile)
             ->setKey(
@@ -41,9 +41,19 @@ class ModelBuilder extends AbstractBuilder
                 $this->codeStructure->hasBelongsTo()
             )
             ->setKey(
-                StubValue::BELONGS_TO->key(),
-                $belongsToStr,
-                ! empty($belongsToStr)
+                StubValue::USE_HAS_MANY->key(),
+                StubValue::USE_HAS_MANY->value(),
+                $this->codeStructure->hasBelongsTo()
+            )
+            ->setKey(
+                StubValue::USE_HAS_ONE->key(),
+                StubValue::USE_HAS_ONE->value(),
+                $this->codeStructure->hasBelongsTo()
+            )
+            ->setKey(
+                StubValue::RELATIONS->key(),
+                $relations,
+                ! empty($relations)
             )
             ->setKey(
                 StubValue::TIMESTAMPS->key(),

--- a/src/Services/CodeStructure/CodeStructure.php
+++ b/src/Services/CodeStructure/CodeStructure.php
@@ -147,7 +147,7 @@ class CodeStructure
     /**
      * @return array<int, SqlTypeMap>
      */
-    public function noInputColumns(): array
+    public function noInputType(): array
     {
         return [
             SqlTypeMap::HAS_MANY,
@@ -162,6 +162,7 @@ class CodeStructure
         foreach ($this->columns as $column) {
             if(
                 $column->type()->isIdType()
+                || in_array($column->type(), $this->noInputType())
                 || $column->isLaravelTimestamp()
             ) {
                 continue;
@@ -216,11 +217,15 @@ class CodeStructure
                 ? $relation->plural()->camel()->value()
                 : $relation->singular()->camel()->value();
 
+            $relationColumn = ($column->type() === SqlTypeMap::HAS_MANY || $column->type() === SqlTypeMap::HAS_ONE)
+                ? $column->relation()->foreignColumn()
+                : $column->column();
+
             $result = $result->newLine()->newLine()->append(
                 $stubBuilder->getFromStub([
                     '{relation}' => $relation,
                     '{relation_model}' => $column->relation()->table()->ucFirstSingular(),
-                    '{relation_column}' => $column->column()
+                    '{relation_column}' => $relationColumn
                 ])
             );
         }
@@ -235,7 +240,7 @@ class CodeStructure
         foreach ($this->columns as $column) {
             if(
                 in_array($column->column(), $this->dateColumns())
-                || in_array($column->type(), $this->noInputColumns())
+                || in_array($column->type(), $this->noInputType())
             ) {
                 continue;
             }
@@ -261,7 +266,7 @@ class CodeStructure
         foreach ($this->columns as $column) {
             if(
                 in_array($column->column(), $this->dateColumns())
-                || in_array($column->type(), $this->noInputColumns())
+                || in_array($column->type(), $this->noInputType())
                 || $column->isId()
             ) {
                 continue;

--- a/src/Services/CodeStructure/ColumnStructure.php
+++ b/src/Services/CodeStructure/ColumnStructure.php
@@ -8,7 +8,7 @@ use DevLnk\LaravelCodeBuilder\Enums\SqlTypeMap;
 
 final class ColumnStructure
 {
-    private string $type;
+    private SqlTypeMap $type;
 
     private ?string $inputType = null;
 
@@ -23,7 +23,7 @@ final class ColumnStructure
         }
     }
 
-    public function type(): string
+    public function type(): SqlTypeMap
     {
         return $this->type;
     }
@@ -43,7 +43,7 @@ final class ColumnStructure
         return $this->relation;
     }
 
-    public function setType(string $type): void
+    public function setType(SqlTypeMap $type): void
     {
         $this->type = $type;
 
@@ -77,7 +77,7 @@ final class ColumnStructure
 
     public function isId(): bool
     {
-        return  SqlTypeMap::from($this->type())->isIdType();
+        return  $this->type()->isIdType();
     }
 
     public function isLaravelTimestamp(): bool
@@ -113,6 +113,6 @@ final class ColumnStructure
             return;
         }
 
-        $this->inputType = SqlTypeMap::from($this->type())->getInputType();
+        $this->inputType = $this->type()->getInputType();
     }
 }


### PR DESCRIPTION
Added support for HasOne and HasMany. HasOne and HasMany relationships cannot be defined using a schema, so they can be specified using flags when generating code:
```shell
php artisan code:build product --has-one=images --has-many=comments
```
Result:
```php
public function comments(): HasMany
{
    return $this->hasMany(Comment::class, 'product_id');
}

public function image(): HasOne
{
    return $this->hasOne(Image::class, 'product_id');
}
```
Flags have `{--has-many=*} {--has-one=*}` specification, so you can specify multiple relationships