### PR TITLE
Code refactoring

### DIFF
--- a/src/Commands/LaravelCodeBuildCommand.php
+++ b/src/Commands/LaravelCodeBuildCommand.php
@@ -173,7 +173,6 @@ class LaravelCodeBuildCommand extends Command
 
         if($isGenerationDir) {
             $genPath = app_path($path);
-
             if(! $fileSystem->isDirectory($genPath)) {
                 $fileSystem->makeDirectory($genPath, recursive: true);
                 $fileSystem->put($genPath . '/.gitignore', "*\n!.gitignore");

--- a/src/Commands/LaravelCodeBuildCommand.php
+++ b/src/Commands/LaravelCodeBuildCommand.php
@@ -171,107 +171,16 @@ class LaravelCodeBuildCommand extends Command
 
         $fileSystem = new Filesystem();
 
-        $genPath = app_path($path);
-
-        $generateDirs = [];
-        $generateProjectDirs = [];
-
-        if(in_array(BuildType::MODEL, $this->builders)) {
-            $generateDirs[] = 'Models';
-        }
-
-        if(
-            in_array(BuildType::ADD_ACTION, $this->builders)
-            || in_array(BuildType::EDIT_ACTION, $this->builders)
-        ) {
-            $generateDirs[] = 'Actions';
-            $generateProjectDirs[] = 'Actions';
-        }
-
-        if(in_array(BuildType::DTO, $this->builders)) {
-            $generateDirs[] = 'DTO';
-            $generateProjectDirs[] = 'DTO';
-        }
-
-        if(in_array(BuildType::REQUEST, $this->builders)) {
-            $generateDirs[] = 'Http/Requests';
-            $generateProjectDirs[] = 'Http/Requests';
-        }
-
-        if(in_array(BuildType::CONTROLLER, $this->builders)) {
-            $generateDirs[] = 'Http/Controllers';
-            $generateProjectDirs[] = 'Http/Controllers';
-        }
-
-        if(in_array(BuildType::ROUTE, $this->builders)) {
-            $generateDirs[] = 'routes';
-        }
-
-        if(in_array(BuildType::FORM, $this->builders)) {
-            $generateDirs[] = 'resources/views';
-        }
-
         if($isGenerationDir) {
+            $genPath = app_path($path);
+
             if(! $fileSystem->isDirectory($genPath)) {
                 $fileSystem->makeDirectory($genPath, recursive: true);
                 $fileSystem->put($genPath . '/.gitignore', "*\n!.gitignore");
             }
-
-            foreach ($generateDirs as $dir) {
-                if(! $fileSystem->isDirectory($genPath . '/' . $dir)) {
-                    $fileSystem->makeDirectory($genPath . '/' . $dir, recursive: true);
-                }
-            }
-        } else {
-            foreach ($generateProjectDirs as $dir) {
-                if(! $fileSystem->isDirectory(app_path($dir))) {
-                    $fileSystem->makeDirectory(app_path($dir));
-                }
-            }
         }
 
-        $this->codePath
-            ->model(
-                $this->codeStructure->entity()->ucFirstSingular() . '.php',
-                $isGenerationDir ? $genPath . "/Models" : app_path('Models'),
-                $isGenerationDir ? 'App\\' . str_replace('/', '\\', $path) . '\\Models' : 'App\\Models'
-            )
-            ->addAction(
-                'Add' . $this->codeStructure->entity()->ucFirstSingular() . 'Action.php',
-                $isGenerationDir ? $genPath . "/Actions" : app_path('Actions'),
-                $isGenerationDir ? 'App\\' . str_replace('/', '\\', $path) . '\\Actions' : 'App\\Actions'
-            )
-            ->editAction(
-                'Edit' . $this->codeStructure->entity()->ucFirstSingular() . 'Action.php',
-                $isGenerationDir ? $genPath . "/Actions" : app_path('Actions'),
-                $isGenerationDir ? 'App\\' . str_replace('/', '\\', $path) . '\\Actions' : 'App\\Actions'
-            )
-            ->request(
-                $this->codeStructure->entity()->ucFirstSingular() . 'Request.php',
-                $isGenerationDir ? $genPath . "/Http/Requests" : app_path('Http/Requests'),
-                $isGenerationDir ? 'App\\' . str_replace('/', '\\', $path) . '\\Http\\Requests' : 'App\\Http\\Requests'
-            )
-            ->controller(
-                $this->codeStructure->entity()->ucFirstSingular() . 'Controller.php',
-                $isGenerationDir ? $genPath . "/Http/Controllers" : app_path('Http/Controllers'),
-                $isGenerationDir ? 'App\\' . str_replace('/', '\\', $path) . '\\Http\\Controllers' : 'App\\Http\\Controllers'
-            )
-            ->route(
-                $this->codeStructure->entity()->lower() . '.php',
-                $isGenerationDir ? $genPath . "/routes" : base_path('routes'),
-                ''
-            )
-            ->form(
-                $this->codeStructure->entity()->lower() . '.blade.php',
-                $isGenerationDir ? $genPath . "/resources/views" : base_path('resources/views'),
-                ''
-            )
-            ->dto(
-                $this->codeStructure->entity()->ucFirstSingular() . 'DTO.php',
-                $isGenerationDir ? $genPath . "/DTO" : app_path('DTO'),
-                $isGenerationDir ? 'App\\' . str_replace('/', '\\', $path) . '\\DTOs' : 'App\\DTOs'
-            )
-        ;
+        $this->codePath->initPaths($this->codeStructure, $path, $isGenerationDir);
 
         if(! $isGenerationDir) {
             foreach ($this->builders as $buildType) {

--- a/src/Providers/LaravelCodeBuilderProvider.php
+++ b/src/Providers/LaravelCodeBuilderProvider.php
@@ -3,6 +3,22 @@
 namespace DevLnk\LaravelCodeBuilder\Providers;
 
 use DevLnk\LaravelCodeBuilder\Commands\LaravelCodeBuildCommand;
+use DevLnk\LaravelCodeBuilder\Services\Builders\Core\AddActionBuilder;
+use DevLnk\LaravelCodeBuilder\Services\Builders\Core\Contracts\AddActionBuilderContract;
+use DevLnk\LaravelCodeBuilder\Services\Builders\Core\Contracts\ControllerBuilderContract;
+use DevLnk\LaravelCodeBuilder\Services\Builders\Core\Contracts\DTOBuilderContract;
+use DevLnk\LaravelCodeBuilder\Services\Builders\Core\Contracts\EditActionBuilderContract;
+use DevLnk\LaravelCodeBuilder\Services\Builders\Core\Contracts\FormBuilderContract;
+use DevLnk\LaravelCodeBuilder\Services\Builders\Core\Contracts\ModelBuilderContract;
+use DevLnk\LaravelCodeBuilder\Services\Builders\Core\Contracts\RequestBuilderContract;
+use DevLnk\LaravelCodeBuilder\Services\Builders\Core\Contracts\RouteBuilderContract;
+use DevLnk\LaravelCodeBuilder\Services\Builders\Core\ControllerBuilder;
+use DevLnk\LaravelCodeBuilder\Services\Builders\Core\DTOBuilder;
+use DevLnk\LaravelCodeBuilder\Services\Builders\Core\EditActionBuilder;
+use DevLnk\LaravelCodeBuilder\Services\Builders\Core\FormBuilder;
+use DevLnk\LaravelCodeBuilder\Services\Builders\Core\ModelBuilder;
+use DevLnk\LaravelCodeBuilder\Services\Builders\Core\RequestBuilder;
+use DevLnk\LaravelCodeBuilder\Services\Builders\Core\RouteBuilder;
 use Illuminate\Support\ServiceProvider;
 
 class LaravelCodeBuilderProvider extends ServiceProvider
@@ -32,5 +48,14 @@ class LaravelCodeBuilderProvider extends ServiceProvider
             __DIR__ . '/../../config/code_builder.php',
             'code_builder'
         );
+
+        $this->app->bind(AddActionBuilderContract::class, AddActionBuilder::class);
+        $this->app->bind(ControllerBuilderContract::class, ControllerBuilder::class);
+        $this->app->bind(DTOBuilderContract::class, DTOBuilder::class);
+        $this->app->bind(EditActionBuilderContract::class, EditActionBuilder::class);
+        $this->app->bind(FormBuilderContract::class, FormBuilder::class);
+        $this->app->bind(ModelBuilderContract::class, ModelBuilder::class);
+        $this->app->bind(RequestBuilderContract::class, RequestBuilder::class);
+        $this->app->bind(RouteBuilderContract::class, RouteBuilder::class);
     }
 }

--- a/src/Services/Builders/BuildFactory.php
+++ b/src/Services/Builders/BuildFactory.php
@@ -8,6 +8,14 @@ use DevLnk\LaravelCodeBuilder\Enums\BuildType;
 use DevLnk\LaravelCodeBuilder\Exceptions\NotFoundBuilderException;
 use DevLnk\LaravelCodeBuilder\Exceptions\NotFoundCodePathException;
 use DevLnk\LaravelCodeBuilder\Services\Builders\Core\AddActionBuilder;
+use DevLnk\LaravelCodeBuilder\Services\Builders\Core\Contracts\AddActionBuilderContract;
+use DevLnk\LaravelCodeBuilder\Services\Builders\Core\Contracts\ControllerBuilderContract;
+use DevLnk\LaravelCodeBuilder\Services\Builders\Core\Contracts\DTOBuilderContract;
+use DevLnk\LaravelCodeBuilder\Services\Builders\Core\Contracts\EditActionBuilderContract;
+use DevLnk\LaravelCodeBuilder\Services\Builders\Core\Contracts\FormBuilderContract;
+use DevLnk\LaravelCodeBuilder\Services\Builders\Core\Contracts\ModelBuilderContract;
+use DevLnk\LaravelCodeBuilder\Services\Builders\Core\Contracts\RequestBuilderContract;
+use DevLnk\LaravelCodeBuilder\Services\Builders\Core\Contracts\RouteBuilderContract;
 use DevLnk\LaravelCodeBuilder\Services\Builders\Core\ControllerBuilder;
 use DevLnk\LaravelCodeBuilder\Services\Builders\Core\DTOBuilder;
 use DevLnk\LaravelCodeBuilder\Services\Builders\Core\EditActionBuilder;
@@ -17,6 +25,8 @@ use DevLnk\LaravelCodeBuilder\Services\Builders\Core\RequestBuilder;
 use DevLnk\LaravelCodeBuilder\Services\Builders\Core\RouteBuilder;
 use DevLnk\LaravelCodeBuilder\Services\CodePath\CodePath;
 use DevLnk\LaravelCodeBuilder\Services\CodeStructure\CodeStructure;
+use Illuminate\Contracts\Container\BindingResolutionException;
+use Illuminate\Contracts\Container\CircularDependencyException;
 use Illuminate\Contracts\Filesystem\FileNotFoundException;
 
 final readonly class BuildFactory
@@ -28,54 +38,47 @@ final readonly class BuildFactory
     }
 
     /**
-     * @throws FileNotFoundException
-     * @throws NotFoundCodePathException
      * @throws NotFoundBuilderException
      */
     public function call(string $buildType, string $stub): void
     {
-        match($buildType) {
-            BuildType::MODEL->value => ModelBuilder::make(
-                $this->codeStructure,
-                $this->codePath,
-                $stub,
-            )->build(),
-            BuildType::ADD_ACTION->value => AddActionBuilder::make(
-                $this->codeStructure,
-                $this->codePath,
-                $stub,
-            )->build(),
-            BuildType::EDIT_ACTION->value => EditActionBuilder::make(
-                $this->codeStructure,
-                $this->codePath,
-                $stub,
-            )->build(),
-            BuildType::REQUEST->value => RequestBuilder::make(
-                $this->codeStructure,
-                $this->codePath,
-                $stub,
-            )->build(),
-            BuildType::CONTROLLER->value => ControllerBuilder::make(
-                $this->codeStructure,
-                $this->codePath,
-                $stub,
-            )->build(),
-            BuildType::ROUTE->value => RouteBuilder::make(
-                $this->codeStructure,
-                $this->codePath,
-                $stub,
-            )->build(),
-            BuildType::FORM->value => FormBuilder::make(
-                $this->codeStructure,
-                $this->codePath,
-                $stub,
-            )->build(),
-            BuildType::DTO->value => DTOBuilder::make(
-                $this->codeStructure,
-                $this->codePath,
-                $stub,
-            )->build(),
+        $classParameters = [
+            'codeStructure' => $this->codeStructure,
+            'codePath' => $this->codePath,
+            'stubFile' => $stub
+        ];
+
+        /**
+         * @var AbstractBuilder $builder
+         */
+        $builder = match($buildType) {
+            BuildType::MODEL->value => app(
+                ModelBuilderContract::class, $classParameters
+            ),
+            BuildType::ADD_ACTION->value => app(
+                AddActionBuilderContract::class, $classParameters
+            ),
+            BuildType::EDIT_ACTION->value => app(
+                EditActionBuilderContract::class, $classParameters
+            ),
+            BuildType::REQUEST->value => app(
+                RequestBuilderContract::class, $classParameters
+            ),
+            BuildType::CONTROLLER->value => app(
+                ControllerBuilderContract::class, $classParameters
+            ),
+            BuildType::ROUTE->value => app(
+                RouteBuilderContract::class, $classParameters
+            ),
+            BuildType::FORM->value => app(
+                FormBuilderContract::class, $classParameters
+            ),
+            BuildType::DTO->value => app(
+                DTOBuilderContract::class, $classParameters
+            ),
             default => throw new NotFoundBuilderException()
         };
+
+        $builder->build();
     }
 }

--- a/src/Services/Builders/BuildFactory.php
+++ b/src/Services/Builders/BuildFactory.php
@@ -6,8 +6,6 @@ namespace DevLnk\LaravelCodeBuilder\Services\Builders;
 
 use DevLnk\LaravelCodeBuilder\Enums\BuildType;
 use DevLnk\LaravelCodeBuilder\Exceptions\NotFoundBuilderException;
-use DevLnk\LaravelCodeBuilder\Exceptions\NotFoundCodePathException;
-use DevLnk\LaravelCodeBuilder\Services\Builders\Core\AddActionBuilder;
 use DevLnk\LaravelCodeBuilder\Services\Builders\Core\Contracts\AddActionBuilderContract;
 use DevLnk\LaravelCodeBuilder\Services\Builders\Core\Contracts\ControllerBuilderContract;
 use DevLnk\LaravelCodeBuilder\Services\Builders\Core\Contracts\DTOBuilderContract;
@@ -16,18 +14,8 @@ use DevLnk\LaravelCodeBuilder\Services\Builders\Core\Contracts\FormBuilderContra
 use DevLnk\LaravelCodeBuilder\Services\Builders\Core\Contracts\ModelBuilderContract;
 use DevLnk\LaravelCodeBuilder\Services\Builders\Core\Contracts\RequestBuilderContract;
 use DevLnk\LaravelCodeBuilder\Services\Builders\Core\Contracts\RouteBuilderContract;
-use DevLnk\LaravelCodeBuilder\Services\Builders\Core\ControllerBuilder;
-use DevLnk\LaravelCodeBuilder\Services\Builders\Core\DTOBuilder;
-use DevLnk\LaravelCodeBuilder\Services\Builders\Core\EditActionBuilder;
-use DevLnk\LaravelCodeBuilder\Services\Builders\Core\FormBuilder;
-use DevLnk\LaravelCodeBuilder\Services\Builders\Core\ModelBuilder;
-use DevLnk\LaravelCodeBuilder\Services\Builders\Core\RequestBuilder;
-use DevLnk\LaravelCodeBuilder\Services\Builders\Core\RouteBuilder;
 use DevLnk\LaravelCodeBuilder\Services\CodePath\CodePath;
 use DevLnk\LaravelCodeBuilder\Services\CodeStructure\CodeStructure;
-use Illuminate\Contracts\Container\BindingResolutionException;
-use Illuminate\Contracts\Container\CircularDependencyException;
-use Illuminate\Contracts\Filesystem\FileNotFoundException;
 
 final readonly class BuildFactory
 {
@@ -45,7 +33,7 @@ final readonly class BuildFactory
         $classParameters = [
             'codeStructure' => $this->codeStructure,
             'codePath' => $this->codePath,
-            'stubFile' => $stub
+            'stubFile' => $stub,
         ];
 
         /**
@@ -53,28 +41,36 @@ final readonly class BuildFactory
          */
         $builder = match($buildType) {
             BuildType::MODEL->value => app(
-                ModelBuilderContract::class, $classParameters
+                ModelBuilderContract::class,
+                $classParameters
             ),
             BuildType::ADD_ACTION->value => app(
-                AddActionBuilderContract::class, $classParameters
+                AddActionBuilderContract::class,
+                $classParameters
             ),
             BuildType::EDIT_ACTION->value => app(
-                EditActionBuilderContract::class, $classParameters
+                EditActionBuilderContract::class,
+                $classParameters
             ),
             BuildType::REQUEST->value => app(
-                RequestBuilderContract::class, $classParameters
+                RequestBuilderContract::class,
+                $classParameters
             ),
             BuildType::CONTROLLER->value => app(
-                ControllerBuilderContract::class, $classParameters
+                ControllerBuilderContract::class,
+                $classParameters
             ),
             BuildType::ROUTE->value => app(
-                RouteBuilderContract::class, $classParameters
+                RouteBuilderContract::class,
+                $classParameters
             ),
             BuildType::FORM->value => app(
-                FormBuilderContract::class, $classParameters
+                FormBuilderContract::class,
+                $classParameters
             ),
             BuildType::DTO->value => app(
-                DTOBuilderContract::class, $classParameters
+                DTOBuilderContract::class,
+                $classParameters
             ),
             default => throw new NotFoundBuilderException()
         };

--- a/src/Services/Builders/Core/AddActionBuilder.php
+++ b/src/Services/Builders/Core/AddActionBuilder.php
@@ -7,10 +7,11 @@ namespace DevLnk\LaravelCodeBuilder\Services\Builders\Core;
 use DevLnk\LaravelCodeBuilder\Enums\BuildType;
 use DevLnk\LaravelCodeBuilder\Exceptions\NotFoundCodePathException;
 use DevLnk\LaravelCodeBuilder\Services\Builders\AbstractBuilder;
+use DevLnk\LaravelCodeBuilder\Services\Builders\Core\Contracts\AddActionBuilderContract;
 use DevLnk\LaravelCodeBuilder\Services\StubBuilder;
 use Illuminate\Contracts\Filesystem\FileNotFoundException;
 
-class AddActionBuilder extends AbstractBuilder
+class AddActionBuilder extends AbstractBuilder implements AddActionBuilderContract
 {
     /**
      * @throws FileNotFoundException

--- a/src/Services/Builders/Core/Contracts/AddActionBuilderContract.php
+++ b/src/Services/Builders/Core/Contracts/AddActionBuilderContract.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace DevLnk\LaravelCodeBuilder\Services\Builders\Core\Contracts;
+
+use DevLnk\LaravelCodeBuilder\Services\Builders\BuilderContract;
+
+interface AddActionBuilderContract extends BuilderContract
+{
+
+}

--- a/src/Services/Builders/Core/Contracts/AddActionBuilderContract.php
+++ b/src/Services/Builders/Core/Contracts/AddActionBuilderContract.php
@@ -6,5 +6,4 @@ use DevLnk\LaravelCodeBuilder\Services\Builders\BuilderContract;
 
 interface AddActionBuilderContract extends BuilderContract
 {
-
 }

--- a/src/Services/Builders/Core/Contracts/ControllerBuilderContract.php
+++ b/src/Services/Builders/Core/Contracts/ControllerBuilderContract.php
@@ -6,5 +6,4 @@ use DevLnk\LaravelCodeBuilder\Services\Builders\BuilderContract;
 
 interface ControllerBuilderContract extends BuilderContract
 {
-
 }

--- a/src/Services/Builders/Core/Contracts/ControllerBuilderContract.php
+++ b/src/Services/Builders/Core/Contracts/ControllerBuilderContract.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace DevLnk\LaravelCodeBuilder\Services\Builders\Core\Contracts;
+
+use DevLnk\LaravelCodeBuilder\Services\Builders\BuilderContract;
+
+interface ControllerBuilderContract extends BuilderContract
+{
+
+}

--- a/src/Services/Builders/Core/Contracts/DTOBuilderContract.php
+++ b/src/Services/Builders/Core/Contracts/DTOBuilderContract.php
@@ -6,5 +6,4 @@ use DevLnk\LaravelCodeBuilder\Services\Builders\BuilderContract;
 
 interface DTOBuilderContract extends BuilderContract
 {
-
 }

--- a/src/Services/Builders/Core/Contracts/DTOBuilderContract.php
+++ b/src/Services/Builders/Core/Contracts/DTOBuilderContract.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace DevLnk\LaravelCodeBuilder\Services\Builders\Core\Contracts;
+
+use DevLnk\LaravelCodeBuilder\Services\Builders\BuilderContract;
+
+interface DTOBuilderContract extends BuilderContract
+{
+
+}

--- a/src/Services/Builders/Core/Contracts/EditActionBuilderContract.php
+++ b/src/Services/Builders/Core/Contracts/EditActionBuilderContract.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace DevLnk\LaravelCodeBuilder\Services\Builders\Core\Contracts;
+
+use DevLnk\LaravelCodeBuilder\Services\Builders\BuilderContract;
+
+interface EditActionBuilderContract extends BuilderContract
+{
+
+}

--- a/src/Services/Builders/Core/Contracts/EditActionBuilderContract.php
+++ b/src/Services/Builders/Core/Contracts/EditActionBuilderContract.php
@@ -6,5 +6,4 @@ use DevLnk\LaravelCodeBuilder\Services\Builders\BuilderContract;
 
 interface EditActionBuilderContract extends BuilderContract
 {
-
 }

--- a/src/Services/Builders/Core/Contracts/FormBuilderContract.php
+++ b/src/Services/Builders/Core/Contracts/FormBuilderContract.php
@@ -6,5 +6,4 @@ use DevLnk\LaravelCodeBuilder\Services\Builders\BuilderContract;
 
 interface FormBuilderContract extends BuilderContract
 {
-
 }

--- a/src/Services/Builders/Core/Contracts/FormBuilderContract.php
+++ b/src/Services/Builders/Core/Contracts/FormBuilderContract.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace DevLnk\LaravelCodeBuilder\Services\Builders\Core\Contracts;
+
+use DevLnk\LaravelCodeBuilder\Services\Builders\BuilderContract;
+
+interface FormBuilderContract extends BuilderContract
+{
+
+}

--- a/src/Services/Builders/Core/Contracts/ModelBuilderContract.php
+++ b/src/Services/Builders/Core/Contracts/ModelBuilderContract.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace DevLnk\LaravelCodeBuilder\Services\Builders\Core\Contracts;
+
+use DevLnk\LaravelCodeBuilder\Services\Builders\BuilderContract;
+
+interface ModelBuilderContract extends BuilderContract
+{
+
+}

--- a/src/Services/Builders/Core/Contracts/ModelBuilderContract.php
+++ b/src/Services/Builders/Core/Contracts/ModelBuilderContract.php
@@ -6,5 +6,4 @@ use DevLnk\LaravelCodeBuilder\Services\Builders\BuilderContract;
 
 interface ModelBuilderContract extends BuilderContract
 {
-
 }

--- a/src/Services/Builders/Core/Contracts/RequestBuilderContract.php
+++ b/src/Services/Builders/Core/Contracts/RequestBuilderContract.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace DevLnk\LaravelCodeBuilder\Services\Builders\Core\Contracts;
+
+use DevLnk\LaravelCodeBuilder\Services\Builders\BuilderContract;
+
+interface RequestBuilderContract extends BuilderContract
+{
+
+}

--- a/src/Services/Builders/Core/Contracts/RequestBuilderContract.php
+++ b/src/Services/Builders/Core/Contracts/RequestBuilderContract.php
@@ -6,5 +6,4 @@ use DevLnk\LaravelCodeBuilder\Services\Builders\BuilderContract;
 
 interface RequestBuilderContract extends BuilderContract
 {
-
 }

--- a/src/Services/Builders/Core/Contracts/RouteBuilderContract.php
+++ b/src/Services/Builders/Core/Contracts/RouteBuilderContract.php
@@ -6,5 +6,4 @@ use DevLnk\LaravelCodeBuilder\Services\Builders\BuilderContract;
 
 interface RouteBuilderContract extends BuilderContract
 {
-
 }

--- a/src/Services/Builders/Core/Contracts/RouteBuilderContract.php
+++ b/src/Services/Builders/Core/Contracts/RouteBuilderContract.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace DevLnk\LaravelCodeBuilder\Services\Builders\Core\Contracts;
+
+use DevLnk\LaravelCodeBuilder\Services\Builders\BuilderContract;
+
+interface RouteBuilderContract extends BuilderContract
+{
+
+}

--- a/src/Services/Builders/Core/ControllerBuilder.php
+++ b/src/Services/Builders/Core/ControllerBuilder.php
@@ -8,10 +8,11 @@ use DevLnk\LaravelCodeBuilder\Enums\BuildType;
 use DevLnk\LaravelCodeBuilder\Enums\StubValue;
 use DevLnk\LaravelCodeBuilder\Exceptions\NotFoundCodePathException;
 use DevLnk\LaravelCodeBuilder\Services\Builders\AbstractBuilder;
+use DevLnk\LaravelCodeBuilder\Services\Builders\Core\Contracts\ControllerBuilderContract;
 use DevLnk\LaravelCodeBuilder\Services\StubBuilder;
 use Illuminate\Contracts\Filesystem\FileNotFoundException;
 
-final class ControllerBuilder extends AbstractBuilder
+final class ControllerBuilder extends AbstractBuilder implements ControllerBuilderContract
 {
     /**
      * @throws FileNotFoundException

--- a/src/Services/Builders/Core/DTOBuilder.php
+++ b/src/Services/Builders/Core/DTOBuilder.php
@@ -7,10 +7,11 @@ namespace DevLnk\LaravelCodeBuilder\Services\Builders\Core;
 use DevLnk\LaravelCodeBuilder\Enums\BuildType;
 use DevLnk\LaravelCodeBuilder\Exceptions\NotFoundCodePathException;
 use DevLnk\LaravelCodeBuilder\Services\Builders\AbstractBuilder;
+use DevLnk\LaravelCodeBuilder\Services\Builders\Core\Contracts\DTOBuilderContract;
 use DevLnk\LaravelCodeBuilder\Services\StubBuilder;
 use Illuminate\Contracts\Filesystem\FileNotFoundException;
 
-class DTOBuilder extends AbstractBuilder
+class DTOBuilder extends AbstractBuilder implements DTOBuilderContract
 {
     /**
      * @throws FileNotFoundException

--- a/src/Services/Builders/Core/EditActionBuilder.php
+++ b/src/Services/Builders/Core/EditActionBuilder.php
@@ -7,10 +7,11 @@ namespace DevLnk\LaravelCodeBuilder\Services\Builders\Core;
 use DevLnk\LaravelCodeBuilder\Enums\BuildType;
 use DevLnk\LaravelCodeBuilder\Exceptions\NotFoundCodePathException;
 use DevLnk\LaravelCodeBuilder\Services\Builders\AbstractBuilder;
+use DevLnk\LaravelCodeBuilder\Services\Builders\Core\Contracts\EditActionBuilderContract;
 use DevLnk\LaravelCodeBuilder\Services\StubBuilder;
 use Illuminate\Contracts\Filesystem\FileNotFoundException;
 
-final class EditActionBuilder extends AbstractBuilder
+final class EditActionBuilder extends AbstractBuilder implements EditActionBuilderContract
 {
     /**
      * @throws FileNotFoundException

--- a/src/Services/Builders/Core/FormBuilder.php
+++ b/src/Services/Builders/Core/FormBuilder.php
@@ -7,10 +7,11 @@ namespace DevLnk\LaravelCodeBuilder\Services\Builders\Core;
 use DevLnk\LaravelCodeBuilder\Enums\BuildType;
 use DevLnk\LaravelCodeBuilder\Exceptions\NotFoundCodePathException;
 use DevLnk\LaravelCodeBuilder\Services\Builders\AbstractBuilder;
+use DevLnk\LaravelCodeBuilder\Services\Builders\Core\Contracts\FormBuilderContract;
 use DevLnk\LaravelCodeBuilder\Services\StubBuilder;
 use Illuminate\Contracts\Filesystem\FileNotFoundException;
 
-final class FormBuilder extends AbstractBuilder
+final class FormBuilder extends AbstractBuilder implements FormBuilderContract
 {
     /**
      * @throws NotFoundCodePathException

--- a/src/Services/Builders/Core/ModelBuilder.php
+++ b/src/Services/Builders/Core/ModelBuilder.php
@@ -8,10 +8,11 @@ use DevLnk\LaravelCodeBuilder\Enums\BuildType;
 use DevLnk\LaravelCodeBuilder\Enums\StubValue;
 use DevLnk\LaravelCodeBuilder\Exceptions\NotFoundCodePathException;
 use DevLnk\LaravelCodeBuilder\Services\Builders\AbstractBuilder;
+use DevLnk\LaravelCodeBuilder\Services\Builders\Core\Contracts\ModelBuilderContract;
 use DevLnk\LaravelCodeBuilder\Services\StubBuilder;
 use Illuminate\Contracts\Filesystem\FileNotFoundException;
 
-class ModelBuilder extends AbstractBuilder
+class ModelBuilder extends AbstractBuilder implements ModelBuilderContract
 {
     /**
      * @throws NotFoundCodePathException

--- a/src/Services/Builders/Core/RequestBuilder.php
+++ b/src/Services/Builders/Core/RequestBuilder.php
@@ -7,10 +7,11 @@ namespace DevLnk\LaravelCodeBuilder\Services\Builders\Core;
 use DevLnk\LaravelCodeBuilder\Enums\BuildType;
 use DevLnk\LaravelCodeBuilder\Exceptions\NotFoundCodePathException;
 use DevLnk\LaravelCodeBuilder\Services\Builders\AbstractBuilder;
+use DevLnk\LaravelCodeBuilder\Services\Builders\Core\Contracts\RequestBuilderContract;
 use DevLnk\LaravelCodeBuilder\Services\StubBuilder;
 use Illuminate\Contracts\Filesystem\FileNotFoundException;
 
-final class RequestBuilder extends AbstractBuilder
+final class RequestBuilder extends AbstractBuilder implements RequestBuilderContract
 {
     /**
      * @throws NotFoundCodePathException

--- a/src/Services/Builders/Core/RouteBuilder.php
+++ b/src/Services/Builders/Core/RouteBuilder.php
@@ -7,10 +7,11 @@ namespace DevLnk\LaravelCodeBuilder\Services\Builders\Core;
 use DevLnk\LaravelCodeBuilder\Enums\BuildType;
 use DevLnk\LaravelCodeBuilder\Exceptions\NotFoundCodePathException;
 use DevLnk\LaravelCodeBuilder\Services\Builders\AbstractBuilder;
+use DevLnk\LaravelCodeBuilder\Services\Builders\Core\Contracts\RouteBuilderContract;
 use DevLnk\LaravelCodeBuilder\Services\StubBuilder;
 use Illuminate\Contracts\Filesystem\FileNotFoundException;
 
-final class RouteBuilder extends AbstractBuilder
+final class RouteBuilder extends AbstractBuilder implements RouteBuilderContract
 {
     /**
      * @throws NotFoundCodePathException

--- a/src/Services/CodePath/AbstractPath.php
+++ b/src/Services/CodePath/AbstractPath.php
@@ -27,6 +27,7 @@ abstract readonly class AbstractPath implements CodePathContract
         if(! is_dir($this->dir)) {
             mkdir($this->dir, recursive: true);
         }
+
         return $this->dir;
     }
 

--- a/src/Services/CodePath/AbstractPath.php
+++ b/src/Services/CodePath/AbstractPath.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace DevLnk\LaravelCodeBuilder\Services\CodePath;
 
+use DevLnk\LaravelCodeBuilder\Enums\BuildType;
+
 abstract readonly class AbstractPath implements CodePathContract
 {
     public function __construct(
@@ -13,14 +15,24 @@ abstract readonly class AbstractPath implements CodePathContract
     ) {
     }
 
+    abstract public function getBuildType(): BuildType;
+
     public function name(): string
     {
         return $this->name;
     }
 
+    public function dir(): string
+    {
+        if(! is_dir($this->dir)) {
+            mkdir($this->dir, recursive: true);
+        }
+        return $this->dir;
+    }
+
     public function file(): string
     {
-        return $this->dir . '/' . $this->name;
+        return $this->dir() . '/' . $this->name;
     }
 
     public function namespace(): string

--- a/src/Services/CodePath/Advanced/TSPath.php
+++ b/src/Services/CodePath/Advanced/TSPath.php
@@ -6,5 +6,5 @@ namespace DevLnk\LaravelCodeBuilder\Services\CodePath\Advanced;
 
 readonly class TSPath
 {
-
+    // TODO TSPath extends AbstractPath
 }

--- a/src/Services/CodePath/Advanced/TSPath.php
+++ b/src/Services/CodePath/Advanced/TSPath.php
@@ -6,5 +6,4 @@ namespace DevLnk\LaravelCodeBuilder\Services\CodePath\Advanced;
 
 readonly class TSPath
 {
-
 }

--- a/src/Services/CodePath/Advanced/TSPath.php
+++ b/src/Services/CodePath/Advanced/TSPath.php
@@ -4,8 +4,7 @@ declare(strict_types=1);
 
 namespace DevLnk\LaravelCodeBuilder\Services\CodePath\Advanced;
 
-use DevLnk\LaravelCodeBuilder\Services\CodePath\AbstractPath;
-
-readonly class TSPath extends AbstractPath
+readonly class TSPath
 {
+
 }

--- a/src/Services/CodePath/CodePath.php
+++ b/src/Services/CodePath/CodePath.php
@@ -14,6 +14,7 @@ use DevLnk\LaravelCodeBuilder\Services\CodePath\Core\FormPath;
 use DevLnk\LaravelCodeBuilder\Services\CodePath\Core\ModelPath;
 use DevLnk\LaravelCodeBuilder\Services\CodePath\Core\RequestPath;
 use DevLnk\LaravelCodeBuilder\Services\CodePath\Core\RoutePath;
+use DevLnk\LaravelCodeBuilder\Services\CodeStructure\CodeStructure;
 
 final class CodePath
 {
@@ -22,91 +23,85 @@ final class CodePath
      */
     private array $paths = [];
 
+    public function initPaths(CodeStructure $codeStructure, string $path, bool $isGenerationDir): void
+    {
+        $genPath = $isGenerationDir ? app_path($path) : '';
+
+        $this
+            ->setPath(
+                new ModelPath(
+                    $codeStructure->entity()->ucFirstSingular() . '.php',
+                    $genPath ? $genPath . "/Models" : app_path('Models'),
+                    $genPath ? 'App\\' . str_replace('/', '\\', $path) . '\\Models' : 'App\\Models'
+                )
+            )
+            ->setPath(
+                new AddActionPath(
+                    'Add' . $codeStructure->entity()->ucFirstSingular() . 'Action.php',
+                    $genPath ? $genPath . "/Actions" : app_path('Actions'),
+                    $genPath ? 'App\\' . str_replace('/', '\\', $path) . '\\Actions' : 'App\\Actions'
+                )
+            )
+            ->setPath(
+                new EditActionPath(
+                    'Edit' . $codeStructure->entity()->ucFirstSingular() . 'Action.php',
+                    $genPath ? $genPath . "/Actions" : app_path('Actions'),
+                    $genPath ? 'App\\' . str_replace('/', '\\', $path) . '\\Actions' : 'App\\Actions'
+                )
+            )
+            ->setPath(
+                new RequestPath(
+                    $codeStructure->entity()->ucFirstSingular() . 'Request.php',
+                    $genPath ? $genPath . "/Http/Requests" : app_path('Http/Requests'),
+                    $genPath ? 'App\\' . str_replace('/', '\\', $path) . '\\Http\\Requests' : 'App\\Http\\Requests'
+                )
+            )
+            ->setPath(
+                new ControllerPath(
+                    $codeStructure->entity()->ucFirstSingular() . 'Controller.php',
+                    $genPath ? $genPath . "/Http/Controllers" : app_path('Http/Controllers'),
+                    $genPath ? 'App\\' . str_replace('/', '\\', $path) . '\\Http\\Controllers' : 'App\\Http\\Controllers'
+                )
+            )
+            ->setPath(
+                new RoutePath(
+                    $codeStructure->entity()->lower() . '.php',
+                    $genPath ? $genPath . "/routes" : base_path('routes'),
+                    ''
+                )
+            )
+            ->setPath(
+                new FormPath(
+                    $codeStructure->entity()->lower() . '.blade.php',
+                    $genPath ? $genPath . "/resources/views" : base_path('resources/views'),
+                    ''
+                )
+            )
+            ->setPath(
+                new DTOPath(
+                    $codeStructure->entity()->ucFirstSingular() . 'DTO.php',
+                    $genPath ? $genPath . "/DTO" : app_path('DTO'),
+                    $genPath ? 'App\\' . str_replace('/', '\\', $path) . '\\DTOs' : 'App\\DTOs'
+                )
+            )
+        ;
+    }
+    
+    public function setPath(AbstractPath $path): self
+    {
+        if(isset($this->paths[$path->getBuildType()->value])) {
+            return $this;
+        }
+        $this->paths[$path->getBuildType()->value] = $path;
+        return $this;
+    }
+    
+
     /**
      * @throws NotFoundCodePathException
      */
     public function path(string $alias): CodePathContract
     {
-        return $this->paths[$alias] ?? throw new NotFoundCodePathException();
-    }
-
-    public function model(string $name, string $dir, string $namespace): self
-    {
-        if(isset($this->paths[BuildType::MODEL->value])) {
-            return $this;
-        }
-        $this->paths[BuildType::MODEL->value] = new ModelPath($name, $dir, $namespace);
-
-        return $this;
-    }
-
-    public function addAction(string $name, string $dir, string $namespace): self
-    {
-        if(isset($this->paths[BuildType::ADD_ACTION->value])) {
-            return $this;
-        }
-        $this->paths[BuildType::ADD_ACTION->value] = new AddActionPath($name, $dir, $namespace);
-
-        return $this;
-    }
-
-    public function editAction(string $name, string $dir, string $namespace): self
-    {
-        if(isset($this->paths[BuildType::EDIT_ACTION->value])) {
-            return $this;
-        }
-        $this->paths[BuildType::EDIT_ACTION->value] = new EditActionPath($name, $dir, $namespace);
-
-        return $this;
-    }
-
-    public function request(string $name, string $dir, string $namespace): self
-    {
-        if(isset($this->paths[BuildType::REQUEST->value])) {
-            return $this;
-        }
-        $this->paths[BuildType::REQUEST->value] = new RequestPath($name, $dir, $namespace);
-
-        return $this;
-    }
-
-    public function controller(string $name, string $dir, string $namespace): self
-    {
-        if(isset($this->paths[BuildType::CONTROLLER->value])) {
-            return $this;
-        }
-        $this->paths[BuildType::CONTROLLER->value] = new ControllerPath($name, $dir, $namespace);
-
-        return $this;
-    }
-
-    public function route(string $name, string $dir, string $namespace): self
-    {
-        if(isset($this->paths[BuildType::ROUTE->value])) {
-            return $this;
-        }
-        $this->paths[BuildType::ROUTE->value] = new RoutePath($name, $dir, $namespace);
-
-        return $this;
-    }
-
-    public function form(string $name, string $dir, string $namespace): self
-    {
-        if(isset($this->paths[BuildType::FORM->value])) {
-            return $this;
-        }
-        $this->paths[BuildType::FORM->value] = new FormPath($name, $dir, $namespace);
-
-        return $this;
-    }
-
-    public function dto(string $name, string $dir, string $namespace): self
-    {
-        if(isset($this->paths[BuildType::DTO->value])) {
-            return $this;
-        }
-        $this->paths[BuildType::DTO->value] = new DTOPath($name, $dir, $namespace);
-
-        return $this;
+        return $this->paths[$alias] ?? throw new NotFoundCodePathException("CodePath alias '$alias' not found");
     }
 }

--- a/src/Services/CodePath/CodePath.php
+++ b/src/Services/CodePath/CodePath.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace DevLnk\LaravelCodeBuilder\Services\CodePath;
 
-use DevLnk\LaravelCodeBuilder\Enums\BuildType;
 use DevLnk\LaravelCodeBuilder\Exceptions\NotFoundCodePathException;
 use DevLnk\LaravelCodeBuilder\Services\CodePath\Core\AddActionPath;
 use DevLnk\LaravelCodeBuilder\Services\CodePath\Core\ControllerPath;
@@ -86,16 +85,17 @@ final class CodePath
             )
         ;
     }
-    
+
     public function setPath(AbstractPath $path): self
     {
         if(isset($this->paths[$path->getBuildType()->value])) {
             return $this;
         }
         $this->paths[$path->getBuildType()->value] = $path;
+
         return $this;
     }
-    
+
 
     /**
      * @throws NotFoundCodePathException

--- a/src/Services/CodePath/CodePathContract.php
+++ b/src/Services/CodePath/CodePathContract.php
@@ -8,6 +8,8 @@ interface CodePathContract
 
     public function rawName(): string;
 
+    public function dir(): string;
+
     public function file(): string;
 
     public function namespace(): string;

--- a/src/Services/CodePath/Core/AddActionPath.php
+++ b/src/Services/CodePath/Core/AddActionPath.php
@@ -4,8 +4,13 @@ declare(strict_types=1);
 
 namespace DevLnk\LaravelCodeBuilder\Services\CodePath\Core;
 
+use DevLnk\LaravelCodeBuilder\Enums\BuildType;
 use DevLnk\LaravelCodeBuilder\Services\CodePath\AbstractPath;
 
 readonly class AddActionPath extends AbstractPath
 {
+    public function getBuildType(): BuildType
+    {
+        return BuildType::ADD_ACTION;
+    }
 }

--- a/src/Services/CodePath/Core/ControllerPath.php
+++ b/src/Services/CodePath/Core/ControllerPath.php
@@ -4,8 +4,13 @@ declare(strict_types=1);
 
 namespace DevLnk\LaravelCodeBuilder\Services\CodePath\Core;
 
+use DevLnk\LaravelCodeBuilder\Enums\BuildType;
 use DevLnk\LaravelCodeBuilder\Services\CodePath\AbstractPath;
 
 readonly class ControllerPath extends AbstractPath
 {
+    public function getBuildType(): BuildType
+    {
+        return BuildType::CONTROLLER;
+    }
 }

--- a/src/Services/CodePath/Core/DTOPath.php
+++ b/src/Services/CodePath/Core/DTOPath.php
@@ -4,8 +4,13 @@ declare(strict_types=1);
 
 namespace DevLnk\LaravelCodeBuilder\Services\CodePath\Core;
 
+use DevLnk\LaravelCodeBuilder\Enums\BuildType;
 use DevLnk\LaravelCodeBuilder\Services\CodePath\AbstractPath;
 
 readonly class DTOPath extends AbstractPath
 {
+    public function getBuildType(): BuildType
+    {
+        return BuildType::DTO;
+    }
 }

--- a/src/Services/CodePath/Core/EditActionPath.php
+++ b/src/Services/CodePath/Core/EditActionPath.php
@@ -4,8 +4,13 @@ declare(strict_types=1);
 
 namespace DevLnk\LaravelCodeBuilder\Services\CodePath\Core;
 
+use DevLnk\LaravelCodeBuilder\Enums\BuildType;
 use DevLnk\LaravelCodeBuilder\Services\CodePath\AbstractPath;
 
 readonly class EditActionPath extends AbstractPath
 {
+    public function getBuildType(): BuildType
+    {
+        return BuildType::EDIT_ACTION;
+    }
 }

--- a/src/Services/CodePath/Core/FormPath.php
+++ b/src/Services/CodePath/Core/FormPath.php
@@ -4,8 +4,13 @@ declare(strict_types=1);
 
 namespace DevLnk\LaravelCodeBuilder\Services\CodePath\Core;
 
+use DevLnk\LaravelCodeBuilder\Enums\BuildType;
 use DevLnk\LaravelCodeBuilder\Services\CodePath\AbstractPath;
 
 readonly class FormPath extends AbstractPath
 {
+    public function getBuildType(): BuildType
+    {
+        return BuildType::FORM;
+    }
 }

--- a/src/Services/CodePath/Core/ModelPath.php
+++ b/src/Services/CodePath/Core/ModelPath.php
@@ -4,8 +4,13 @@ declare(strict_types=1);
 
 namespace DevLnk\LaravelCodeBuilder\Services\CodePath\Core;
 
+use DevLnk\LaravelCodeBuilder\Enums\BuildType;
 use DevLnk\LaravelCodeBuilder\Services\CodePath\AbstractPath;
 
 readonly class ModelPath extends AbstractPath
 {
+    public function getBuildType(): BuildType
+    {
+        return BuildType::MODEL;
+    }
 }

--- a/src/Services/CodePath/Core/RequestPath.php
+++ b/src/Services/CodePath/Core/RequestPath.php
@@ -4,8 +4,13 @@ declare(strict_types=1);
 
 namespace DevLnk\LaravelCodeBuilder\Services\CodePath\Core;
 
+use DevLnk\LaravelCodeBuilder\Enums\BuildType;
 use DevLnk\LaravelCodeBuilder\Services\CodePath\AbstractPath;
 
 readonly class RequestPath extends AbstractPath
 {
+    public function getBuildType(): BuildType
+    {
+        return BuildType::REQUEST;
+    }
 }

--- a/src/Services/CodePath/Core/RoutePath.php
+++ b/src/Services/CodePath/Core/RoutePath.php
@@ -4,8 +4,13 @@ declare(strict_types=1);
 
 namespace DevLnk\LaravelCodeBuilder\Services\CodePath\Core;
 
+use DevLnk\LaravelCodeBuilder\Enums\BuildType;
 use DevLnk\LaravelCodeBuilder\Services\CodePath\AbstractPath;
 
 readonly class RoutePath extends AbstractPath
 {
+    public function getBuildType(): BuildType
+    {
+        return BuildType::ROUTE;
+    }
 }


### PR DESCRIPTION
Builders are now binded in the provider. Now, if you wish, you can replace the builder with your own:
```php
class CustomAddActionBuilder extends AbstractBuilder implements AddActionBuilderContract
{
    /**
     * @throws FileNotFoundException
     * @throws NotFoundCodePathException
     */
    public function build(): void
    {
        //TODO your code
    }
}
```
Provider:
```php
$this->app->bind(AddActionBuilderContract::class, CustomAddActionBuilder::class);
```