### PR TITLE
Crud

### DIFF
--- a/code_stubs/AddAction.stub
+++ b/code_stubs/AddAction.stub
@@ -10,14 +10,14 @@ final class {name}
 {
     public function handle(array $data): {model_name}
     {
-        $model = new {model_name}();
+        ${entity_singular} = new {model_name}();
 
-        $model->fill($data);
+        ${entity_singular}->fill($data);
 
-        $model->save();
+        ${entity_singular}->save();
 
-        $model->refresh();
+        ${entity_singular}->refresh();
 
-        return $model;
+        return ${entity_singular};
     }
 }

--- a/code_stubs/Controller.stub
+++ b/code_stubs/Controller.stub
@@ -18,7 +18,12 @@ class {name} extends Controller
     {
         ${entity_plural} = {model}::query()->get();
 
-        return view('{entity_singular}.index', compact('{entity_plural}'));
+        return view('{entity_singular}.table', compact('{entity_plural}'));
+    }
+
+    public function create(): View
+    {
+        return view('{entity_singular}.form');
     }
 
     public function store({request_name} $request, {add_action_name} $action): RedirectResponse
@@ -30,11 +35,25 @@ class {name} extends Controller
         return back();
     }
 
-    public function edit(string $id, {request_name} $request, {edit_action_name} $action): RedirectResponse
+    public function edit(string $id)
+    {
+        ${entity_singular} = {model}::query()->where('id', $id)->firstOrFail();
+
+        return view('{entity_singular}.form', compact('{entity_singular}'));
+    }
+
+    public function update(string $id, {request_name} $request, {edit_action_name} $action): RedirectResponse
     {
         $data = $request->validated();
 
         ${entity_singular} = $action->handle((int) $id, $data);
+
+        return back();
+    }
+
+    public function destroy(string $id)
+    {
+        {model}::query()->where('id', $id)->delete();
 
         return back();
     }

--- a/code_stubs/Controller.stub
+++ b/code_stubs/Controller.stub
@@ -5,18 +5,27 @@ declare(strict_types=1);
 namespace {namespace};
 
 use Illuminate\Http\RedirectResponse;
+use Illuminate\Contracts\View\View;
 {use_controller}
 use {add_action_namespace};
 use {edit_action_namespace};
 use {request_namespace};
+use {model_namespace};
 
 class {name} extends Controller
 {
+    public function index(): View
+    {
+        ${entity_plural} = {model}::query()->get();
+
+        return view('{entity_singular}.index', compact('{entity_plural}'));
+    }
+
     public function store({request_name} $request, {add_action_name} $action): RedirectResponse
     {
         $data = $request->validated();
         
-        $model = $action->handle($data);
+        ${entity_singular} = $action->handle($data);
 
         return back();
     }
@@ -25,7 +34,7 @@ class {name} extends Controller
     {
         $data = $request->validated();
 
-        $model = $action->handle((int) $id, $data);
+        ${entity_singular} = $action->handle((int) $id, $data);
 
         return back();
     }

--- a/code_stubs/EditAction.stub
+++ b/code_stubs/EditAction.stub
@@ -8,16 +8,20 @@ use {model_namespace};
 
 final class {name}
 {
-    public function handle(int $id, array $data): {model_name}
+    public function handle(int $id, array $data): ?{model_name}
     {
-        $model = {model_name}::query()->where('id', $id)->first();
-        
-        $model->fill($data);
+        ${entity_singular} = {model_name}::query()->where('id', $id)->first();
 
-        $model->save();
+        if(is_null(${entity_singular})) {
+            return null;
+        }
 
-        $model->refresh();
+        ${entity_singular}->fill($data);
 
-        return $model;
+        ${entity_singular}->save();
+
+        ${entity_singular}->refresh();
+
+        return ${entity_singular};
     }
 }

--- a/code_stubs/Form.stub
+++ b/code_stubs/Form.stub
@@ -1,4 +1,4 @@
-<form action="{{ route('{name}.store') }}" method="POST">
+<form action="{{ route('{entity_plural}.store') }}" method="POST">
     @csrf{inputs}
     <button type="submit">Submit</button>
 </form>

--- a/code_stubs/Route.stub
+++ b/code_stubs/Route.stub
@@ -5,7 +5,11 @@ declare(strict_types=1);
 use {controller_namespace};
 use Illuminate\Support\Facades\Route;
 
-Route::prefix('{name}')->controller({controller_name}::class)->group(function (): void {
-    Route::post('/', 'store')->name('{name}.store');
-    Route::post('/{id}', 'edit')->name('{name}.edit');
+Route::prefix('{entity_plural}')->controller({controller_name}::class)->group(function (): void {
+    Route::get('/', 'index')->name('{entity_plural}.index');
+    Route::get('/create', 'create')->name('{entity_plural}.create');
+    Route::post('/', 'store')->name('{entity_plural}.store');
+    Route::get('/{id}/edit', 'edit')->name('{entity_plural}.edit');
+    Route::put('/{id}', 'update')->name('{entity_plural}.update');
+    Route::delete('/{id}', 'destroy')->name('{entity_plural}.destroy');
 });

--- a/code_stubs/Table.stub
+++ b/code_stubs/Table.stub
@@ -1,0 +1,7 @@
+<table>
+<tbody>
+<tr>
+<td>1<td>
+<\tr>
+</tbody>
+</table>

--- a/code_stubs/Table.stub
+++ b/code_stubs/Table.stub
@@ -1,7 +1,12 @@
 <table>
-<tbody>
-<tr>
-<td>1<td>
-<\tr>
-</tbody>
+    <thead>
+        <tr>{thead}
+        </tr>
+    </thead>
+    <tbody>
+    @foreach(${entity_plural} as ${entity_singular})
+        <tr>{tbody}
+        </tr>
+    @endforeach
+    </tbody>
 </table>

--- a/config/code_builder.php
+++ b/config/code_builder.php
@@ -13,6 +13,7 @@ return [
         BuildType::ROUTE,
         BuildType::FORM,
         BuildType::DTO,
+        BuildType::TABLE,
         // Additionally
     ],
 

--- a/src/Commands/LaravelCodeBuildCommand.php
+++ b/src/Commands/LaravelCodeBuildCommand.php
@@ -19,7 +19,7 @@ use function Laravel\Prompts\select;
 
 class LaravelCodeBuildCommand extends Command
 {
-    protected $signature = 'code:build {entity} {table?} {--model} {--request} {--addAction} {--editAction} {--request} {--controller} {--route} {--form} {--DTO} {--builders} {--has-many=*} {--has-one=*} {--belongs-to-many=*}';
+    protected $signature = 'code:build {entity} {table?} {--model} {--request} {--addAction} {--editAction} {--request} {--controller} {--route} {--form} {--DTO} {--table} {--builders} {--has-many=*} {--has-one=*} {--belongs-to-many=*}';
 
     private CodePath $codePath;
 
@@ -161,6 +161,7 @@ class LaravelCodeBuildCommand extends Command
             BuildType::ROUTE,
             BuildType::FORM,
             BuildType::DTO,
+            BuildType::TABLE,
         ];
 
         foreach ($builders as $builder) {

--- a/src/Enums/BuildType.php
+++ b/src/Enums/BuildType.php
@@ -22,6 +22,8 @@ enum BuildType: string
 
     case DTO = 'DTO';
 
+    case TABLE = 'table';
+
     public function stub(): string
     {
         return match ($this) {
@@ -33,6 +35,7 @@ enum BuildType: string
             self::ROUTE => 'Route',
             self::FORM => 'Form',
             self::DTO => 'DTO',
+            self::TABLE => 'Table',
         };
     }
 }

--- a/src/Providers/LaravelCodeBuilderProvider.php
+++ b/src/Providers/LaravelCodeBuilderProvider.php
@@ -12,6 +12,7 @@ use DevLnk\LaravelCodeBuilder\Services\Builders\Core\Contracts\FormBuilderContra
 use DevLnk\LaravelCodeBuilder\Services\Builders\Core\Contracts\ModelBuilderContract;
 use DevLnk\LaravelCodeBuilder\Services\Builders\Core\Contracts\RequestBuilderContract;
 use DevLnk\LaravelCodeBuilder\Services\Builders\Core\Contracts\RouteBuilderContract;
+use DevLnk\LaravelCodeBuilder\Services\Builders\Core\Contracts\TableBuilderContract;
 use DevLnk\LaravelCodeBuilder\Services\Builders\Core\ControllerBuilder;
 use DevLnk\LaravelCodeBuilder\Services\Builders\Core\DTOBuilder;
 use DevLnk\LaravelCodeBuilder\Services\Builders\Core\EditActionBuilder;
@@ -19,6 +20,7 @@ use DevLnk\LaravelCodeBuilder\Services\Builders\Core\FormBuilder;
 use DevLnk\LaravelCodeBuilder\Services\Builders\Core\ModelBuilder;
 use DevLnk\LaravelCodeBuilder\Services\Builders\Core\RequestBuilder;
 use DevLnk\LaravelCodeBuilder\Services\Builders\Core\RouteBuilder;
+use DevLnk\LaravelCodeBuilder\Services\Builders\Core\TableBuilder;
 use Illuminate\Support\ServiceProvider;
 
 class LaravelCodeBuilderProvider extends ServiceProvider
@@ -40,6 +42,7 @@ class LaravelCodeBuilderProvider extends ServiceProvider
         $this->app->bind(ModelBuilderContract::class, ModelBuilder::class);
         $this->app->bind(RequestBuilderContract::class, RequestBuilder::class);
         $this->app->bind(RouteBuilderContract::class, RouteBuilder::class);
+        $this->app->bind(TableBuilderContract::class, TableBuilder::class);
     }
 
     public function boot(): void

--- a/src/Services/Builders/BuildFactory.php
+++ b/src/Services/Builders/BuildFactory.php
@@ -14,6 +14,7 @@ use DevLnk\LaravelCodeBuilder\Services\Builders\Core\Contracts\FormBuilderContra
 use DevLnk\LaravelCodeBuilder\Services\Builders\Core\Contracts\ModelBuilderContract;
 use DevLnk\LaravelCodeBuilder\Services\Builders\Core\Contracts\RequestBuilderContract;
 use DevLnk\LaravelCodeBuilder\Services\Builders\Core\Contracts\RouteBuilderContract;
+use DevLnk\LaravelCodeBuilder\Services\Builders\Core\Contracts\TableBuilderContract;
 use DevLnk\LaravelCodeBuilder\Services\CodePath\CodePath;
 use DevLnk\LaravelCodeBuilder\Services\CodeStructure\CodeStructure;
 
@@ -70,6 +71,10 @@ final readonly class BuildFactory
             ),
             BuildType::DTO->value => app(
                 DTOBuilderContract::class,
+                $classParameters
+            ),
+            BuildType::TABLE->value => app(
+                TableBuilderContract::class,
                 $classParameters
             ),
             default => throw new NotFoundBuilderException()

--- a/src/Services/Builders/Core/AddActionBuilder.php
+++ b/src/Services/Builders/Core/AddActionBuilder.php
@@ -28,6 +28,7 @@ class AddActionBuilder extends AbstractBuilder implements AddActionBuilderContra
                 '{model_namespace}' => $modelPath->namespace() . '\\' . $modelPath->rawName(),
                 '{name}' => $actionPath->rawName(),
                 '{model_name}' => $modelPath->rawName(),
+                '{entity_singular}' => $this->codeStructure->entity()->singular(),
             ]);
     }
 }

--- a/src/Services/Builders/Core/Contracts/TableBuilderContract.php
+++ b/src/Services/Builders/Core/Contracts/TableBuilderContract.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DevLnk\LaravelCodeBuilder\Services\Builders\Core\Contracts;
+
+use DevLnk\LaravelCodeBuilder\Services\Builders\BuilderContract;
+
+interface TableBuilderContract extends BuilderContract
+{
+
+}

--- a/src/Services/Builders/Core/ControllerBuilder.php
+++ b/src/Services/Builders/Core/ControllerBuilder.php
@@ -24,6 +24,7 @@ final class ControllerBuilder extends AbstractBuilder implements ControllerBuild
         $addActionPath = $this->codePath->path(BuildType::ADD_ACTION->value);
         $editActionPath = $this->codePath->path(BuildType::EDIT_ACTION->value);
         $requestPath = $this->codePath->path(BuildType::REQUEST->value);
+        $modelPath = $this->codePath->path(BuildType::MODEL->value);
 
         StubBuilder::make($this->stubFile)
             ->setKey(
@@ -35,8 +36,12 @@ final class ControllerBuilder extends AbstractBuilder implements ControllerBuild
                 '{namespace}' => $controllerPath->namespace(),
                 '{add_action_namespace}' => $addActionPath->namespace() . '\\' . $addActionPath->rawName(),
                 '{edit_action_namespace}' => $editActionPath->namespace() . '\\' . $editActionPath->rawName(),
+                '{model_namespace}' => $modelPath->namespace() . '\\' . $modelPath->rawName(),
+                '{model}' => $modelPath->rawName(),
                 '{request_namespace}' => $requestPath->namespace() . '\\' . $requestPath->rawName(),
                 '{name}' => $controllerPath->rawName(),
+                '{entity_plural}' => $this->codeStructure->entity()->plural(),
+                '{entity_singular}' => $this->codeStructure->entity()->singular(),
                 '{request_name}' => $requestPath->rawName(),
                 '{add_action_name}' => $addActionPath->rawName(),
                 '{edit_action_name}' => $editActionPath->rawName(),

--- a/src/Services/Builders/Core/EditActionBuilder.php
+++ b/src/Services/Builders/Core/EditActionBuilder.php
@@ -27,6 +27,7 @@ final class EditActionBuilder extends AbstractBuilder implements EditActionBuild
                 '{namespace}' => $actionPath->namespace(),
                 '{model_namespace}' => $modelPath->namespace() . '\\' . $modelPath->rawName(),
                 '{name}' => $actionPath->rawName(),
+                '{entity_singular}' => $this->codeStructure->entity()->singular(),
                 '{model_name}' => $modelPath->rawName(),
             ]);
     }

--- a/src/Services/Builders/Core/FormBuilder.php
+++ b/src/Services/Builders/Core/FormBuilder.php
@@ -19,12 +19,11 @@ final class FormBuilder extends AbstractBuilder implements FormBuilderContract
      */
     public function build(): void
     {
-        $routePath = $this->codePath->path(BuildType::ROUTE->value);
         $formPath = $this->codePath->path(BuildType::FORM->value);
 
         StubBuilder::make($this->stubFile)
             ->makeFromStub($formPath->file(), [
-                '{name}' => $routePath->rawName(),
+                '{entity_plural}' => $this->codeStructure->entity()->plural(),
                 '{inputs}' => $this->codeStructure->columnsToForm(),
             ]);
     }

--- a/src/Services/Builders/Core/RouteBuilder.php
+++ b/src/Services/Builders/Core/RouteBuilder.php
@@ -25,7 +25,7 @@ final class RouteBuilder extends AbstractBuilder implements RouteBuilderContract
         StubBuilder::make($this->stubFile)
             ->makeFromStub($routePath->file(), [
                 '{controller_namespace}' => $controllerPath->namespace() . '\\' . $controllerPath->rawName(),
-                '{name}' => $routePath->rawName(),
+                '{entity_plural}' => $this->codeStructure->entity()->plural(),
                 '{controller_name}' => $controllerPath->rawName(),
             ]);
     }

--- a/src/Services/Builders/Core/TableBuilder.php
+++ b/src/Services/Builders/Core/TableBuilder.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DevLnk\LaravelCodeBuilder\Services\Builders\Core;
+
+use DevLnk\LaravelCodeBuilder\Enums\BuildType;
+use DevLnk\LaravelCodeBuilder\Exceptions\NotFoundCodePathException;
+use DevLnk\LaravelCodeBuilder\Services\Builders\AbstractBuilder;
+use DevLnk\LaravelCodeBuilder\Services\Builders\Core\Contracts\TableBuilderContract;
+use DevLnk\LaravelCodeBuilder\Services\StubBuilder;
+use Illuminate\Contracts\Filesystem\FileNotFoundException;
+
+final class TableBuilder extends AbstractBuilder implements TableBuilderContract
+{
+    /**
+     * @throws NotFoundCodePathException
+     * @throws FileNotFoundException
+     */
+    public function build(): void
+    {
+        $tablePath = $this->codePath->path(BuildType::TABLE->value);
+
+        StubBuilder::make($this->stubFile)
+            ->makeFromStub($tablePath->file());
+    }
+}

--- a/src/Services/Builders/Core/TableBuilder.php
+++ b/src/Services/Builders/Core/TableBuilder.php
@@ -22,6 +22,11 @@ final class TableBuilder extends AbstractBuilder implements TableBuilderContract
         $tablePath = $this->codePath->path(BuildType::TABLE->value);
 
         StubBuilder::make($this->stubFile)
-            ->makeFromStub($tablePath->file());
+            ->makeFromStub($tablePath->file(), [
+                '{thead}' => $this->codeStructure->columnsToThead(),
+                '{entity_plural}' => $this->codeStructure->entity()->plural(),
+                '{entity_singular}' => $this->codeStructure->entity()->singular(),
+                '{tbody}' => $this->codeStructure->columnsToTbody(),
+            ]);
     }
 }

--- a/src/Services/CodePath/CodePath.php
+++ b/src/Services/CodePath/CodePath.php
@@ -13,6 +13,7 @@ use DevLnk\LaravelCodeBuilder\Services\CodePath\Core\FormPath;
 use DevLnk\LaravelCodeBuilder\Services\CodePath\Core\ModelPath;
 use DevLnk\LaravelCodeBuilder\Services\CodePath\Core\RequestPath;
 use DevLnk\LaravelCodeBuilder\Services\CodePath\Core\RoutePath;
+use DevLnk\LaravelCodeBuilder\Services\CodePath\Core\TablePath;
 use DevLnk\LaravelCodeBuilder\Services\CodeStructure\CodeStructure;
 
 final class CodePath
@@ -76,8 +77,8 @@ final class CodePath
             )
             ->setPath(
                 new FormPath(
-                    $codeStructure->entity()->lower() . '.blade.php',
-                    $genPath ? $genPath . "/resources/views" : base_path('resources/views'),
+                    'form.blade.php',
+                    $genPath ? $genPath . "/resources/views/" . $codeStructure->entity()->lower() : base_path('resources/views/' . $codeStructure->entity()->lower()),
                     ''
                 )
             )
@@ -86,6 +87,13 @@ final class CodePath
                     $codeStructure->entity()->ucFirstSingular() . 'DTO.php',
                     $genPath ? $genPath . "/DTO" : app_path('DTO'),
                     $genPath ? str_replace('/', '\\', $namespace) . '\\DTO' : 'App\\DTO'
+                )
+            )
+            ->setPath(
+                new TablePath(
+                    'table.blade.php',
+                    $genPath ? $genPath . "/resources/views/" . $codeStructure->entity()->lower() : base_path('resources/views/' . $codeStructure->entity()->lower()),
+                    ''
                 )
             )
         ;

--- a/src/Services/CodePath/Core/TablePath.php
+++ b/src/Services/CodePath/Core/TablePath.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DevLnk\LaravelCodeBuilder\Services\CodePath\Core;
+
+use DevLnk\LaravelCodeBuilder\Enums\BuildType;
+use DevLnk\LaravelCodeBuilder\Services\CodePath\AbstractPath;
+
+readonly class TablePath extends AbstractPath
+{
+    public function getBuildType(): BuildType
+    {
+        return BuildType::TABLE;
+    }
+}

--- a/src/Services/CodeStructure/CodeStructure.php
+++ b/src/Services/CodeStructure/CodeStructure.php
@@ -9,6 +9,7 @@ use DevLnk\LaravelCodeBuilder\Services\CodeStructure\Traits\DTOColumns;
 use DevLnk\LaravelCodeBuilder\Services\CodeStructure\Traits\FormColumns;
 use DevLnk\LaravelCodeBuilder\Services\CodeStructure\Traits\ModelColumns;
 use DevLnk\LaravelCodeBuilder\Services\CodeStructure\Traits\RequestColumns;
+use DevLnk\LaravelCodeBuilder\Services\CodeStructure\Traits\TableColumns;
 use DevLnk\LaravelCodeBuilder\Support\NameStr;
 use DevLnk\LaravelCodeBuilder\Support\Traits\DataTrait;
 
@@ -18,6 +19,7 @@ class CodeStructure
     use RequestColumns;
     use FormColumns;
     use DTOColumns;
+    use TableColumns;
     use DataTrait;
 
     /**

--- a/src/Services/CodeStructure/Traits/TableColumns.php
+++ b/src/Services/CodeStructure/Traits/TableColumns.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace DevLnk\LaravelCodeBuilder\Services\CodeStructure\Traits;
+
+trait TableColumns
+{
+    public function columnsToThead(): string
+    {
+        $result = "";
+        foreach ($this->columns() as $column) {
+            $result .= str('')
+                ->newLine()
+                ->append("\t\t\t")
+                ->append("<th>{$column->name()}</th>")
+                ->value()
+            ;
+        }
+        return $result;
+    }
+
+    public function columnsToTbody(): string
+    {
+        $result = "";
+        foreach ($this->columns() as $column) {
+            $result .= str('')
+                ->newLine()
+                ->append("\t\t\t")
+                ->append("<td>{{ \${$this->entity()->singular()}->{$column->column()} }}</td>")
+                ->value()
+            ;
+        }
+        return $result;
+    }
+}

--- a/src/Support/NameStr.php
+++ b/src/Support/NameStr.php
@@ -51,6 +51,11 @@ final readonly class NameStr
 
     public function plural(): string
     {
-        return str($this->lower())->plural()->value();
+        return str($this->camel())->plural()->value();
+    }
+
+    public function singular(): string
+    {
+        return str($this->camel())->singular()->value();
     }
 }

--- a/tests/Feature/CommandAddActionTest.php
+++ b/tests/Feature/CommandAddActionTest.php
@@ -37,7 +37,7 @@ class CommandAddActionTest extends TestCase
         $this->assertStringContainsString('use App\Models\Product;', $file);
         $this->assertStringContainsString('final class AddProductAction', $file);
         $this->assertStringContainsString('public function handle(array $data): Product', $file);
-        $this->assertStringContainsString('$model = new Product()', $file);
+        $this->assertStringContainsString('$product = new Product()', $file);
     }
 
     #[Test]
@@ -54,7 +54,7 @@ class CommandAddActionTest extends TestCase
         $this->assertStringContainsString('use App\Models\Foo;', $file);
         $this->assertStringContainsString('final class AddFooAction', $file);
         $this->assertStringContainsString('public function handle(array $data): Foo', $file);
-        $this->assertStringContainsString('$model = new Foo()', $file);
+        $this->assertStringContainsString('$foo = new Foo()', $file);
     }
 
     public function tearDown(): void

--- a/tests/Feature/CommandControllerTest.php
+++ b/tests/Feature/CommandControllerTest.php
@@ -36,7 +36,7 @@ final class CommandControllerTest extends TestCase
         $this->assertStringContainsString('namespace App\Http\Controllers;', $file);
         $this->assertStringContainsString('class ProductController extends Controller', $file);
         $this->assertStringContainsString(
-            'public function edit(string $id, ProductRequest $request, EditProductAction $action): RedirectResponse',
+            'public function update(string $id, ProductRequest $request, EditProductAction $action): RedirectResponse',
             $file
         );
         $this->assertStringContainsString('ProductRequest $request, EditProductAction $action', $file);

--- a/tests/Feature/CommandEditActionTest.php
+++ b/tests/Feature/CommandEditActionTest.php
@@ -36,8 +36,8 @@ class CommandEditActionTest extends TestCase
         $this->assertStringContainsString('namespace App\Actions;', $file);
         $this->assertStringContainsString('use App\Models\Product;', $file);
         $this->assertStringContainsString('final class EditProductAction', $file);
-        $this->assertStringContainsString('public function handle(int $id, array $data): Product', $file);
-        $this->assertStringContainsString("\$model = Product::query()->where('id', \$id)->first();", $file);
+        $this->assertStringContainsString('public function handle(int $id, array $data): ?Product', $file);
+        $this->assertStringContainsString("\$product = Product::query()->where('id', \$id)->first();", $file);
     }
 
     #[Test]
@@ -53,8 +53,8 @@ class CommandEditActionTest extends TestCase
 
         $this->assertStringContainsString('use App\Models\Foo;', $file);
         $this->assertStringContainsString('final class EditFooAction', $file);
-        $this->assertStringContainsString('public function handle(int $id, array $data): Foo', $file);
-        $this->assertStringContainsString("\$model = Foo::query()->where('id', \$id)->first();", $file);
+        $this->assertStringContainsString('public function handle(int $id, array $data): ?Foo', $file);
+        $this->assertStringContainsString("\$foo = Foo::query()->where('id', \$id)->first();", $file);
     }
 
     public function tearDown(): void

--- a/tests/Feature/CommandFormTest.php
+++ b/tests/Feature/CommandFormTest.php
@@ -33,7 +33,7 @@ final class CommandFormTest extends TestCase
         $this->assertFileExists($this->path . 'product/form.blade.php');
 
         $file = $this->filesystem->get($this->path . 'product/form.blade.php');
-        $this->assertStringContainsString("<form action=\"{{ route('product.store') }}\" method=\"POST\">", $file);
+        $this->assertStringContainsString("<form action=\"{{ route('products.store') }}\" method=\"POST\">", $file);
         $this->assertStringContainsString('<input id="content" name="content" value="{{ old(\'content\') }}"/>', $file);
         $this->assertStringContainsString('<input id="sort_number" name="sort_number" value="{{ old(\'sort_number\') }}" type="number"/>', $file);
         $this->assertStringContainsString('<select id="user_id" name="user_id">', $file);
@@ -65,7 +65,7 @@ final class CommandFormTest extends TestCase
         $this->assertFileExists($this->path . 'user/form.blade.php');
 
         $file = $this->filesystem->get($this->path . 'user/form.blade.php');
-        $this->assertStringContainsString("<form action=\"{{ route('user.store') }}\" method=\"POST\">", $file);
+        $this->assertStringContainsString("<form action=\"{{ route('users.store') }}\" method=\"POST\">", $file);
         $this->assertStringContainsString('<input id="email" name="email" value="{{ old(\'email\') }}" type="email"/>', $file);
         $this->assertStringContainsString('<input id="password" name="password" value="{{ old(\'password\') }}" type="password"/>', $file);
     }
@@ -79,7 +79,7 @@ final class CommandFormTest extends TestCase
 
         $this->assertFileExists($this->path . 'foo/form.blade.php');
         $file = $this->filesystem->get($this->path . 'foo/form.blade.php');
-        $this->assertStringContainsString("<form action=\"{{ route('foo.store') }}\" method=\"POST\">", $file);
+        $this->assertStringContainsString("<form action=\"{{ route('foos.store') }}\" method=\"POST\">", $file);
     }
 
     public function tearDown(): void

--- a/tests/Feature/CommandFormTest.php
+++ b/tests/Feature/CommandFormTest.php
@@ -30,9 +30,9 @@ final class CommandFormTest extends TestCase
             ->expectsQuestion('Table', 'products')
             ->expectsQuestion('Where to generate the result?', '_default');
 
-        $this->assertFileExists($this->path . 'product.blade.php');
+        $this->assertFileExists($this->path . 'product/form.blade.php');
 
-        $file = $this->filesystem->get($this->path . 'product.blade.php');
+        $file = $this->filesystem->get($this->path . 'product/form.blade.php');
         $this->assertStringContainsString("<form action=\"{{ route('product.store') }}\" method=\"POST\">", $file);
         $this->assertStringContainsString('<input id="content" name="content" value="{{ old(\'content\') }}"/>', $file);
         $this->assertStringContainsString('<input id="sort_number" name="sort_number" value="{{ old(\'sort_number\') }}" type="number"/>', $file);
@@ -49,9 +49,9 @@ final class CommandFormTest extends TestCase
             ->expectsQuestion('Where to generate the result?', '_default')
         ;
 
-        $this->assertFileExists($this->path . 'product.blade.php');
+        $this->assertFileExists($this->path . 'product/form.blade.php');
 
-        $file = $this->filesystem->get($this->path . 'product.blade.php');
+        $file = $this->filesystem->get($this->path . 'product/form.blade.php');
         $this->assertStringContainsString('<select id="properties" name="properties" multiple>', $file);
     }
 
@@ -62,9 +62,9 @@ final class CommandFormTest extends TestCase
             ->expectsQuestion('Table', 'users')
             ->expectsQuestion('Where to generate the result?', '_default');
 
-        $this->assertFileExists($this->path . 'user.blade.php');
+        $this->assertFileExists($this->path . 'user/form.blade.php');
 
-        $file = $this->filesystem->get($this->path . 'user.blade.php');
+        $file = $this->filesystem->get($this->path . 'user/form.blade.php');
         $this->assertStringContainsString("<form action=\"{{ route('user.store') }}\" method=\"POST\">", $file);
         $this->assertStringContainsString('<input id="email" name="email" value="{{ old(\'email\') }}" type="email"/>', $file);
         $this->assertStringContainsString('<input id="password" name="password" value="{{ old(\'password\') }}" type="password"/>', $file);
@@ -77,16 +77,16 @@ final class CommandFormTest extends TestCase
             ->expectsQuestion('Table', 'products')
             ->expectsQuestion('Where to generate the result?', '_default');
 
-        $this->assertFileExists($this->path . 'foo.blade.php');
-        $file = $this->filesystem->get($this->path . 'foo.blade.php');
+        $this->assertFileExists($this->path . 'foo/form.blade.php');
+        $file = $this->filesystem->get($this->path . 'foo/form.blade.php');
         $this->assertStringContainsString("<form action=\"{{ route('foo.store') }}\" method=\"POST\">", $file);
     }
 
     public function tearDown(): void
     {
-        $this->filesystem->delete($this->path . 'product.blade.php');
-        $this->filesystem->delete($this->path . 'foo.blade.php');
-        $this->filesystem->delete($this->path . 'user.blade.php');
+        $this->filesystem->delete($this->path . 'product/form.blade.php');
+        $this->filesystem->delete($this->path . 'foo/form.blade.php');
+        $this->filesystem->delete($this->path . 'user/form.blade.php');
         parent::tearDown();
     }
 }

--- a/tests/Feature/CommandRouteTest.php
+++ b/tests/Feature/CommandRouteTest.php
@@ -33,9 +33,9 @@ final class CommandRouteTest extends TestCase
         $this->assertFileExists($this->path . 'product.php');
         $file = $this->filesystem->get($this->path . 'product.php');
         $this->assertStringContainsString('use App\Http\Controllers\ProductController;', $file);
-        $this->assertStringContainsString("Route::prefix('product')->controller(ProductController::class)->group(function (): void {", $file);
-        $this->assertStringContainsString("Route::post('/', 'store')->name('product.store');", $file);
-        $this->assertStringContainsString("Route::post('/{id}', 'edit')->name('product.edit');", $file);
+        $this->assertStringContainsString("Route::prefix('products')->controller(ProductController::class)->group(function (): void {", $file);
+        $this->assertStringContainsString("Route::post('/', 'store')->name('products.store');", $file);
+        $this->assertStringContainsString("Route::put('/{id}', 'update')->name('products.update');", $file);
     }
 
     #[Test]
@@ -48,9 +48,9 @@ final class CommandRouteTest extends TestCase
         $this->assertFileExists($this->path . 'foo.php');
         $file = $this->filesystem->get($this->path . 'foo.php');
         $this->assertStringContainsString('use App\Http\Controllers\FooController;', $file);
-        $this->assertStringContainsString("Route::prefix('foo')->controller(FooController::class)->group(function (): void {", $file);
-        $this->assertStringContainsString("Route::post('/', 'store')->name('foo.store');", $file);
-        $this->assertStringContainsString("Route::post('/{id}', 'edit')->name('foo.edit');", $file);
+        $this->assertStringContainsString("Route::prefix('foos')->controller(FooController::class)->group(function (): void {", $file);
+        $this->assertStringContainsString("Route::post('/', 'store')->name('foos.store');", $file);
+        $this->assertStringContainsString("Route::put('/{id}', 'update')->name('foos.update');", $file);
     }
 
     public function tearDown(): void

--- a/tests/Feature/CommandRouteTest.php
+++ b/tests/Feature/CommandRouteTest.php
@@ -34,8 +34,12 @@ final class CommandRouteTest extends TestCase
         $file = $this->filesystem->get($this->path . 'product.php');
         $this->assertStringContainsString('use App\Http\Controllers\ProductController;', $file);
         $this->assertStringContainsString("Route::prefix('products')->controller(ProductController::class)->group(function (): void {", $file);
+        $this->assertStringContainsString("Route::get('/', 'index')->name('products.index');", $file);
+        $this->assertStringContainsString("Route::get('/create', 'create')->name('products.create');", $file);
         $this->assertStringContainsString("Route::post('/', 'store')->name('products.store');", $file);
+        $this->assertStringContainsString("Route::get('/{id}/edit', 'edit')->name('products.edit');", $file);
         $this->assertStringContainsString("Route::put('/{id}', 'update')->name('products.update');", $file);
+        $this->assertStringContainsString("Route::delete('/{id}', 'destroy')->name('products.destroy');", $file);
     }
 
     #[Test]

--- a/tests/Feature/CommandSummaryTest.php
+++ b/tests/Feature/CommandSummaryTest.php
@@ -16,6 +16,8 @@ class CommandSummaryTest extends TestCase
 
     private string $formPath = '';
 
+    private string $tablePath = '';
+
     private string $modelPath = '';
 
     private string $requestPath = '';
@@ -34,7 +36,8 @@ class CommandSummaryTest extends TestCase
 
         $this->actionPath = app_path('Actions/');
         $this->controllerPath = app_path('Http/Controllers/');
-        $this->formPath = base_path('resources/views/');
+        $this->formPath = base_path('resources/views/product/');
+        $this->tablePath = base_path('resources/views/product/');
         $this->modelPath = app_path('Models/');
         $this->requestPath = app_path('Http/Requests/');
         $this->routePath = base_path('routes/');
@@ -53,7 +56,8 @@ class CommandSummaryTest extends TestCase
         $this->assertFileExists($this->actionPath . 'AddProductAction.php');
         $this->assertFileExists($this->actionPath . 'EditProductAction.php');
         $this->assertFileExists($this->controllerPath . 'ProductController.php');
-        $this->assertFileExists($this->formPath . 'product.blade.php');
+        $this->assertFileExists($this->formPath . 'form.blade.php');
+        $this->assertFileExists($this->formPath . 'table.blade.php');
         $this->assertFileExists($this->modelPath . 'Product.php');
         $this->assertFileExists($this->requestPath . 'ProductRequest.php');
         $this->assertFileExists($this->routePath . 'product.php');
@@ -69,7 +73,8 @@ class CommandSummaryTest extends TestCase
 
         $this->actionPath = app_path('Generation/Actions/');
         $this->controllerPath = app_path('Generation/Http/Controllers/');
-        $this->formPath = app_path('Generation/resources/views/');
+        $this->formPath = app_path('Generation/resources/views/product/');
+        $this->tablePath = app_path('Generation/resources/views/product/');
         $this->modelPath = app_path('Generation/Models/');
         $this->requestPath = app_path('Generation/Http/Requests/');
         $this->routePath = app_path('Generation/routes/');
@@ -87,7 +92,8 @@ class CommandSummaryTest extends TestCase
         $this->assertFileExists($this->actionPath . 'AddProductAction.php');
         $this->assertFileExists($this->actionPath . 'EditProductAction.php');
         $this->assertFileExists($this->controllerPath . 'ProductController.php');
-        $this->assertFileExists($this->formPath . 'product.blade.php');
+        $this->assertFileExists($this->formPath . 'form.blade.php');
+        $this->assertFileExists($this->tablePath . 'table.blade.php');
         $this->assertFileExists($this->modelPath . 'Product.php');
         $this->assertFileExists($this->requestPath . 'ProductRequest.php');
         $this->assertFileExists($this->routePath . 'product.php');
@@ -99,7 +105,8 @@ class CommandSummaryTest extends TestCase
         $this->filesystem->delete($this->actionPath . 'AddProductAction.php');
         $this->filesystem->delete($this->actionPath . 'EditProductAction.php');
         $this->filesystem->delete($this->controllerPath . 'ProductController.php');
-        $this->filesystem->delete($this->formPath . 'product.blade.php');
+        $this->filesystem->delete($this->formPath . 'form.blade.php');
+        $this->filesystem->delete($this->tablePath . 'table.blade.php');
         $this->filesystem->delete($this->modelPath . 'Product.php');
         $this->filesystem->delete($this->requestPath . 'ProductRequest.php');
         $this->filesystem->delete($this->routePath . 'product.php');

--- a/tests/Feature/CommandTableTest.php
+++ b/tests/Feature/CommandTableTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DevLnk\LaravelCodeBuilder\Tests\Feature;
+
+use DevLnk\LaravelCodeBuilder\Tests\TestCase;
+use Illuminate\Filesystem\Filesystem;
+use PHPUnit\Framework\Attributes\Test;
+
+final class CommandTableTest extends TestCase
+{
+    private string $path = '';
+
+    private Filesystem $filesystem;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->filesystem = new Filesystem();
+
+        $this->path = base_path('resources/views/product/');
+    }
+
+    #[Test]
+    public function testProduct()
+    {
+        $this->artisan('code:build product --table')
+            ->expectsQuestion('Table', 'products')
+            ->expectsQuestion('Where to generate the result?', '_default');
+
+        $this->assertFileExists($this->path . 'table.blade.php');
+    }
+
+    public function tearDown(): void
+    {
+        $this->filesystem->delete($this->path . 'table.blade.php');
+        parent::tearDown();
+    }
+}

--- a/tests/Feature/CommandTableTest.php
+++ b/tests/Feature/CommandTableTest.php
@@ -31,6 +31,15 @@ final class CommandTableTest extends TestCase
             ->expectsQuestion('Where to generate the result?', '_default');
 
         $this->assertFileExists($this->path . 'table.blade.php');
+
+        $file = $this->filesystem->get($this->path . 'table.blade.php');
+        $this->assertStringContainsString("<th>id</th>", $file);
+        $this->assertStringContainsString("<th>user_id</th>", $file);
+        $this->assertStringContainsString("<th>created_at</th>", $file);
+        $this->assertStringContainsString("@foreach(\$products as \$product)", $file);
+        $this->assertStringContainsString("<td>{{ \$product->id }}</td>", $file);
+        $this->assertStringContainsString("<td>{{ \$product->user_id }}</td>", $file);
+        $this->assertStringContainsString("<td>{{ \$product->created_at }}</td>", $file);
     }
 
     public function tearDown(): void


### PR DESCRIPTION
Added support for all crud routes except show:
```php
Route::prefix('products')->controller(ProductController::class)->group(function (): void {
    Route::get('/', 'index')->name('products.index');
    Route::get('/create', 'create')->name('products.create');
    Route::post('/', 'store')->name('products.store');
    Route::get('/{id}/edit', 'edit')->name('products.edit');
    Route::put('/{id}', 'update')->name('products.update');
    Route::delete('/{id}', 'destroy')->name('products.destroy');
});
```
Added table builder for index method:
```html
<table>
    <thead>
        <tr>
	  <th>id</th>
	  <th>title</th>
	  <th>content</th>
	  <th>sort_number</th>
	  <th>user_id</th>
	  <th>category_id</th>
	  <th>is_active</th>
	  <th>created_at</th>
	  <th>updated_at</th>
	  <th>deleted_at</th>
        </tr>
    </thead>
    <tbody>
    @foreach($products as $product)
        <tr>
	  <td>{{ $product->id }}</td>
	  <td>{{ $product->title }}</td>
	  <td>{{ $product->content }}</td>
	  <td>{{ $product->sort_number }}</td>
	  <td>{{ $product->user_id }}</td>
	  <td>{{ $product->category_id }}</td>
	  <td>{{ $product->is_active }}</td>
	  <td>{{ $product->created_at }}</td>
	  <td>{{ $product->updated_at }}</td>
	  <td>{{ $product->deleted_at }}</td>
        </tr>
    @endforeach
    </tbody>
</table>
```
