### PR TITLE
Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,15 +103,15 @@ use DevLnk\LaravelCodeBuilder\Enums\BuildType;
 
 return [
     'builders' => [
-        BuildType::MODEL,
-//        BuildType::DTO,
-//        BuildType::ADD_ACTION,
-//        BuildType::EDIT_ACTION,
-//        BuildType::REQUEST,
-//        BuildType::CONTROLLER,
-//        BuildType::ROUTE,
-//        BuildType::TABLE,
-        BuildType::FORM,
+        'model',
+//        'addAction',
+//        'editAction',
+//        'request',
+//        'controller',
+//        'route',
+        'form',
+//        'DTO',
+//        'table',
     ],
     //...
 ];

--- a/config/code_builder.php
+++ b/config/code_builder.php
@@ -1,19 +1,17 @@
 <?php
 
-use DevLnk\LaravelCodeBuilder\Enums\BuildType;
-
 return [
     'builders' => [
         // Core
-        BuildType::MODEL,
-        BuildType::ADD_ACTION,
-        BuildType::EDIT_ACTION,
-        BuildType::REQUEST,
-        BuildType::CONTROLLER,
-        BuildType::ROUTE,
-        BuildType::FORM,
-        BuildType::DTO,
-        BuildType::TABLE,
+        'model',
+        'addAction',
+        'editAction',
+        'request',
+        'controller',
+        'route',
+        'form',
+        'DTO',
+        'table',
         // Additionally
     ],
 

--- a/src/Commands/LaravelCodeBuildCommand.php
+++ b/src/Commands/LaravelCodeBuildCommand.php
@@ -194,7 +194,7 @@ class LaravelCodeBuildCommand extends Command
         }
 
         if($this->option('builders')) {
-            foreach (config('code_builder.builders', []) as $builder) {
+            foreach ($this->configBuilders() as $builder) {
                 if(! in_array($builder, $this->builders)) {
                     $this->builders[] = $builder;
                 }
@@ -202,7 +202,7 @@ class LaravelCodeBuildCommand extends Command
         }
 
         if(empty($this->builders)) {
-            $this->builders = config('code_builder.builders');
+            $this->builders = $this->configBuilders();
         }
     }
 
@@ -263,6 +263,17 @@ class LaravelCodeBuildCommand extends Command
             BuildType::DTO,
             BuildType::TABLE,
         ];
+    }
+
+    /**
+     * @return array<int, BuildTypeContract>
+     */
+    protected function configBuilders(): array
+    {
+        $builders = (array) config('code_builder.builders', []);
+        return array_map(function ($builder) {
+            return ($builder instanceof BuildType) ? $builder : BuildType::from($builder);
+        }, $builders);
     }
 
     protected function projectFileName(string $filePath): string

--- a/src/Services/Builders/Core/ModelBuilder.php
+++ b/src/Services/Builders/Core/ModelBuilder.php
@@ -147,8 +147,8 @@ class ModelBuilder extends AbstractBuilder implements ModelBuilderContract
             $result = $result->newLine()->newLine()->append(
                 $stubBuilder->getFromStub([
                     '{relation}' => $relation,
-                    '{relation_model}' => $column->relation()->table()->ucFirstSingular(),
                     '{relation_column}' => $relationColumn,
+                    '{relation_model}' => $column->relation()->model(),
                 ])
             );
         }

--- a/src/Services/CodeStructure/RelationStructure.php
+++ b/src/Services/CodeStructure/RelationStructure.php
@@ -26,4 +26,14 @@ final class RelationStructure
     {
         return $this->table;
     }
+
+    public function model(): string
+    {
+        return $this->table
+            ->str()
+            ->camel()
+            ->singular()
+            ->ucfirst()
+            ->value();
+    }
 }


### PR DESCRIPTION
- Correcting the model name in relation
- Now builders in the configuration are specified via the string type
```php
return [
    'builders' => [
        // Core
        'model',
        'addAction',
        'editAction',
        'request',
        'controller',
        'route',
        'form',
        'DTO',
        'table',
        // Additionally
    ],
];
```